### PR TITLE
feat: メニューバー強化・FindWidget・コミット比較機能を追加

### DIFF
--- a/.aidd/steering/product.md
+++ b/.aidd/steering/product.md
@@ -1,0 +1,35 @@
+# Product Overview
+
+Git Keizu (系図) is a VS Code extension that renders Git history as an interactive graph, enabling developers to visualize branches, tags, and commit relationships at a glance and perform common Git operations directly from the graph.
+
+Forked from neo-git-graph (asispts), originally from Git Graph (mhutchie, MIT commit 4af8583).
+
+## Core Capabilities
+
+- **Interactive Graph View**: Visualize all branches, tags, and uncommitted changes in a connected commit graph with configurable colors and styles (rounded/angular)
+- **Commit Inspection**: Click any commit to view detailed changes, diffs, author info, and file-level modifications
+- **Git Operations**: Right-click to create/checkout/delete/rename/merge branches, add/delete/push tags, cherry-pick, revert, or reset — all without leaving VS Code
+- **Multi-Repository Support**: Auto-discovers Git repositories in the workspace; switch between repos from a dropdown
+- **Author Avatars**: Optionally fetches commit author avatars from GitHub, GitLab, or Gravatar
+
+## Target Use Cases
+
+- **Daily Git workflow**: Developers exploring branch history and performing routine Git operations through a visual interface rather than CLI
+- **Code review preparation**: Understanding branch relationships and commit sequences before reviewing or merging
+- **Repository orientation**: Onboarding to unfamiliar codebases by visualizing the commit topology
+
+## Value Proposition
+
+- **Security-hardened fork**: Full security audit (27 issues fixed) — shell injection eliminated, input validation on all git commands, XSS prevention, SSRF protection
+- **Combined branch labels**: Local and remote branches pointing to the same commit merge into a single pill label (`[main | origin]`)
+- **Modernized codebase**: async/await throughout, ES2020 target, Vitest test suite, esbuild bundling
+- **MIT licensed**: Permissive open-source license
+
+## Distribution
+
+- Published as `numlia-vs.git-keizu` on VS Marketplace and Open VSX
+- Minimum VS Code version: 1.74.0
+
+---
+
+_Focus on patterns and purpose, not exhaustive feature lists_

--- a/.aidd/steering/structure.md
+++ b/.aidd/steering/structure.md
@@ -1,0 +1,100 @@
+# Project Structure
+
+## Organization Philosophy
+
+**Two-runtime separation**: The codebase is split into two fully isolated TypeScript projects (`src/` and `web/`) with separate tsconfig files, build targets, and runtime environments. They share type definitions but no executable code.
+
+## Directory Patterns
+
+### Extension Backend (`src/`)
+
+**Location**: `src/`
+**Purpose**: Node.js code running in VS Code's extension host. Handles Git operations, state, and webview management.
+**Entry**: `src/extension.ts` → bundled to `out/extension.js`
+**Pattern**: One class per file, each class owns a single responsibility:
+
+- `DataSource` — Git CLI wrapper (spawn-based)
+- `GitGraphView` — Webview panel lifecycle and message routing
+- `RepoManager` — Repository auto-discovery and watching
+- `AvatarManager` — Avatar fetching and caching
+- `ExtensionState` — State persistence (column widths, last repo, cache)
+- `Config` — Typed settings wrapper
+
+### Webview Frontend (`web/`)
+
+**Location**: `web/`
+**Purpose**: Browser code running in VS Code's Chromium webview. Renders UI and handles user interactions.
+**Entry**: `web/main.ts` → bundled to `out/web.min.js`
+**Pattern**: Main class (`GitGraphView`) in `main.ts`, extracted modules for distinct UI concerns:
+
+- `graph.ts` — SVG graph rendering engine
+- `dropdown.ts` — Reusable dropdown component
+- `dialogs.ts` — Confirmation/form/error dialogs
+- `fileTree.ts` — Nested file tree from commit changes
+- `contextMenu.ts` — Right-click context menu
+- `branchLabels.ts` — Branch/tag label rendering
+- `dates.ts` — Date formatting
+- `utils.ts` — Shared utilities (escapeHtml, sendMessage, SVG icons)
+
+### Tests (`tests/`)
+
+**Location**: `tests/`
+**Purpose**: Vitest unit tests, mirroring the two-runtime structure.
+**Pattern**: `tests/src/` for backend tests, `tests/web/` for webview tests. Test files named `*.test.ts`.
+
+- `tests/web/setup.ts` — Mocks `acquireVsCodeApi()` for webview test environment
+
+### Static Resources (`resources/`, `media/`)
+
+**Location**: `resources/`, `media/`
+**Purpose**: Static assets used by the extension and webview.
+
+- `resources/` — Extension icon, webview HTML templates
+- `media/` — CSS stylesheets for the webview
+
+### Build Output (`out/`)
+
+**Location**: `out/`
+**Purpose**: esbuild output (git-ignored). Contains bundled `extension.js` and `web.min.js`.
+
+### Reference / Notes (`notes/`)
+
+**Location**: `notes/`
+**Purpose**: Historical reference. Contains the original vscode-git-graph and neo-git-graph sources for comparison. Not part of the build.
+
+## Naming Conventions
+
+- **Files**: camelCase (`dataSource.ts`, `gitGraphView.ts`, `branchLabels.ts`)
+- **Classes**: PascalCase (`DataSource`, `GitGraphView`, `AvatarManager`)
+- **Interfaces**: PascalCase with descriptive prefixes (`GitCommitNode`, `RequestAddTag`, `ResponseLoadCommits`)
+- **Type aliases**: PascalCase (`DateFormat`, `GraphStyle`, `GitResetMode`)
+- **Message commands**: camelCase string literals (`"loadCommits"`, `"checkoutBranch"`)
+- **Settings keys**: kebab-case under `git-keizu.*` namespace (`git-keizu.graphStyle`)
+
+## Import Organization
+
+```typescript
+// External modules first (sorted by simple-import-sort)
+import * as vscode from "vscode";
+
+// Internal modules (sorted alphabetically)
+import { AvatarManager } from "./avatarManager";
+import { DataSource } from "./dataSource";
+import { GitGraphView } from "./gitGraphView";
+```
+
+- **No path aliases**: All imports use relative paths (`./`, `../`)
+- **Import sorting**: Enforced by `simple-import-sort/imports` (oxlint, auto-fixable)
+- **No cross-runtime imports**: `src/` and `web/` never import from each other
+
+## Code Organization Principles
+
+- **Single responsibility**: Each file owns one class or one cohesive set of utilities
+- **Message-driven architecture**: All communication between runtimes flows through the typed `RequestMessage`/`ResponseMessage` protocol
+- **No shared executable code**: `src/types.ts` defines shared interfaces only; no functions cross the runtime boundary
+- **Security at the boundary**: Input validation happens in `dataSource.ts` (commit hash, paths, reset mode) and `gitGraphView.ts` (repo validation); `web/utils.ts` handles XSS escaping
+- **State isolation**: Extension state (`ExtensionState`) persists to disk; webview state (`viewState`) is initialized from the extension on panel creation
+
+---
+
+_Document patterns, not file trees. New files following patterns shouldn't require updates_

--- a/.aidd/steering/tech.md
+++ b/.aidd/steering/tech.md
@@ -1,0 +1,158 @@
+# Technology Stack
+
+## Architecture
+
+**Two-runtime VS Code extension**: The codebase consists of two isolated TypeScript projects that communicate via a typed message protocol.
+
+- **Extension Host** (`src/`): Node.js backend running in VS Code's extension host process. Manages Git operations, state persistence, avatar fetching, and repository discovery.
+- **Webview** (`web/`): Browser-based frontend running in VS Code's Chromium webview. Renders the commit graph, handles user interactions, and delegates all Git operations to the extension host.
+
+**Communication**: The webview posts `RequestMessage` to the extension; the extension processes it (typically spawning a Git subprocess) and sends back a `ResponseMessage`. Both message types are discriminated unions defined in `src/types.ts`.
+
+## Core Technologies
+
+- **Language**: TypeScript 5.9 (strict mode enabled in both projects)
+- **Runtime (backend)**: Node.js (CommonJS, ES6 target)
+- **Runtime (frontend)**: Browser/Chromium (IIFE, ES2020 target)
+- **Extension API**: VS Code Extension API (`@types/vscode ~1.74.0`)
+- **Bundler**: esbuild (separate builds for src and web)
+- **Package Manager**: pnpm 10.29.3 (via `npm exec --yes -- pnpm@10.29.3` when no global pnpm)
+
+## Key Libraries
+
+| Category  | Library          | Purpose                                                              |
+| --------- | ---------------- | -------------------------------------------------------------------- |
+| Build     | esbuild          | Bundle src → `out/extension.js`, web → `out/web.min.js`              |
+| Lint      | oxlint + plugins | Static analysis (import, typescript, unicorn plugins)                |
+| Format    | oxfmt            | Code formatting (printWidth 100, 2-space indent, no trailing commas) |
+| Test      | Vitest           | Unit testing with v8 coverage                                        |
+| Packaging | @vscode/vsce     | VS Code extension packaging and publishing                           |
+
+No runtime dependencies — the extension uses only VS Code API and Node.js built-ins.
+
+## Development Standards
+
+### Type Safety
+
+- **TypeScript strict mode**: Both `src/tsconfig.json` and `web/tsconfig.json` enable `"strict": true`
+- **noImplicitAny**: Enabled in both projects
+- **noUnusedLocals / noUnusedParameters**: Enabled in both projects
+- **oxlint `typescript/no-explicit-any`**: Warned (not error, but flagged)
+- **Discriminated unions**: Message protocol uses `command` field as discriminant for type-safe request/response handling
+- **Type-only files**: `src/types.ts` for all shared interfaces, `web/global.d.ts` for webview globals
+
+### Code Quality
+
+- **Linter**: oxlint with plugins: `import`, `typescript`, `unicorn`, `simple-import-sort`
+- **Formatter**: oxfmt (printWidth 100, 2-space indent, no trailing commas)
+- **Key rules enforced**:
+  - `eqeqeq`: Strict equality only
+  - `no-var`: const/let only
+  - `unicorn/prefer-node-protocol`: `node:` prefix for built-ins
+  - `simple-import-sort/imports`: Sorted imports
+  - `no-eval` / `no-implied-eval`: Security
+  - `no-throw-literal`: Proper error objects
+
+### Code Conventions
+
+- **Node built-ins**: Always use `node:` protocol prefix (`node:fs/promises`, `node:path`, `node:child_process`)
+- **Strings**: Template literals everywhere (no `+` concatenation)
+- **Async**: `async/await` only (no `.then()` chains, no callbacks for fs)
+- **Git commands**: Always use `spawn()` via `runGitCommandSpawn`/`spawnGit` in `dataSource.ts` (never `exec` — shell injection prevention)
+
+### Testing
+
+- **Framework**: Vitest (v4)
+- **Test files**: `tests/src/utils.test.ts`, `tests/web/utils.test.ts` (36 tests)
+- **Setup**: `tests/web/setup.ts` mocks `acquireVsCodeApi()` for webview tests
+- **Coverage**: v8 provider, covers `src/**/*.ts` and `web/**/*.ts` (excludes `types.ts`, `global.d.ts`)
+- **CI integration**: `pnpm run test:ci` (vitest run)
+- **Test supplement**: [`docs/test-supplement.md`](docs/test-supplement.md)
+
+## Development Environment
+
+### Required Tools
+
+- Node.js 22 (CI matrix)
+- pnpm 10.29.3 (via corepack or `npm exec`)
+- VS Code (for testing the extension)
+
+### Common Commands
+
+```bash
+# Install
+npm exec --yes -- pnpm@10.29.3 install
+
+# Quality checks (CI order)
+pnpm run format          # oxfmt --check
+pnpm run lint            # oxlint
+pnpm run typecheck       # tsc -p ./src --noEmit && tsc -p ./web --noEmit
+pnpm run test:ci         # vitest run
+
+# Fix
+pnpm run format:fix      # oxfmt .
+pnpm run lint:fix        # oxlint --fix
+
+# Build
+pnpm run compile         # clean + compile-src + compile-web
+
+# Single test
+pnpm exec vitest run tests/src/utils.test.ts
+```
+
+### CI Pipeline
+
+GitHub Actions workflow (`ci.yaml`):
+
+- Triggers: push to main, PRs to main
+- Steps: install → format check → lint → typecheck → test
+- Node 22, pnpm via corepack
+
+## Security Architecture
+
+Security is a core design principle (27-item audit completed):
+
+- **Shell injection prevention**: All git commands use `child_process.spawn()` exclusively; `exec()` removed entirely
+- **Git binary validation**: `isValidGitPath()` validates absolute path + `git`/`git.exe` basename
+- **Input validation**: Commit hash format validation, repository path validation against registered repos, path traversal prevention (`..` check)
+- **XSS prevention**: `escapeHtml()` applied to all dynamic values inserted into webview HTML
+- **SSRF protection**: Avatar fetch URLs restricted to allowlist (GitHub, GitLab, Gravatar)
+
+## Message Protocol
+
+The extension uses a typed request/response message protocol:
+
+- **`RequestMessage`**: Discriminated union (21 command types) — webview → extension
+- **`ResponseMessage`**: Discriminated union (21 command types) — extension → webview
+- **Discriminant field**: `command` (string literal type)
+- **Pattern**: Webview calls `sendMessage()` → extension's `onDidReceiveMessage` handler dispatches to `DataSource` methods → response posted back
+
+## Settings Namespace
+
+All user-facing settings under `git-keizu.*` (12 settings):
+
+- Graph appearance: `graphColours`, `graphStyle`, `tabIconColourTheme`
+- Display: `dateFormat`, `dateType`, `showUncommittedChanges`, `showCurrentBranchByDefault`
+- Behavior: `autoCenterCommitDetailsView`, `fetchAvatars`, `initialLoadCommits`, `loadMoreCommits`
+- Discovery: `maxDepthOfRepoSearch`, `showStatusBarItem`
+
+Read via `src/config.ts` wrapper around `vscode.workspace.getConfiguration('git-keizu')`.
+
+## Key Technical Decisions
+
+| Decision                              | Rationale                                                                              |
+| ------------------------------------- | -------------------------------------------------------------------------------------- |
+| `spawn()` over `exec()`               | Shell injection prevention — no shell interpretation of arguments                      |
+| Separate tsconfig per runtime         | src targets Node.js (ES6/CJS), web targets browser (ES2020/IIFE)                       |
+| esbuild over webpack/rollup           | Fast bundling, minimal config, single-file output for both runtimes                    |
+| oxlint + oxfmt over ESLint + Prettier | Faster execution, unified Rust-based toolchain                                         |
+| No runtime dependencies               | Extension relies only on VS Code API + Node.js built-ins, minimizing supply chain risk |
+| Typed message protocol                | Discriminated unions ensure type-safe communication between runtimes                   |
+
+## DDL Management / Migration Strategy
+
+Not applicable — this is a VS Code extension with no database. State is persisted via VS Code's `globalState` and local filesystem (avatar cache, repo state).
+
+---
+
+_Document standards and patterns, not every dependency_

--- a/docs/testing/perspectives/menu-bar-enhancement-test.md
+++ b/docs/testing/perspectives/menu-bar-enhancement-test.md
@@ -1,0 +1,178 @@
+# テスト観点表: メニューバー強化
+
+> Generated: 2026-02-24T20:00:00Z
+> Origin: AIDD pipeline (aidd-spec-tasks-test)
+> Spec: `notes/features/001-menu-bar/`
+
+---
+
+## 対象: Task 1.2 Foundation テスト（定数・型定義・アイコン検証）
+
+| Case ID   | Input / Precondition                                | Perspective (Equivalence / Boundary) | Expected Result                | Notes                                          |
+| --------- | --------------------------------------------------- | ------------------------------------ | ------------------------------ | ---------------------------------------------- |
+| TC-F-N-01 | UNCOMMITTED_CHANGES_HASH 定数を参照                 | Equivalence - normal                 | 値が `"*"` と一致する          | 既存のハードコード値との互換性保証             |
+| TC-F-N-02 | VALID_UNCOMMITTED_RESET_MODES を参照                | Equivalence - normal                 | `"mixed"` を含む               | -                                              |
+| TC-F-N-03 | VALID_UNCOMMITTED_RESET_MODES を参照                | Equivalence - normal                 | `"hard"` を含む                | -                                              |
+| TC-F-B-01 | VALID_UNCOMMITTED_RESET_MODES のサイズ              | Boundary - exact count               | Set のサイズが 2 である        | "soft" は含まないことの間接検証                |
+| TC-F-A-01 | VALID_UNCOMMITTED_RESET_MODES に `"soft"` で has()  | Equivalence - invalid                | `false` を返す                 | Uncommitted リセットでは soft は意味をなさない |
+| TC-F-A-02 | VALID_UNCOMMITTED_RESET_MODES に `""` で has()      | Boundary - empty                     | `false` を返す                 | -                                              |
+| TC-F-A-03 | VALID_UNCOMMITTED_RESET_MODES に `"MIXED"` で has() | Boundary - case sensitivity          | `false` を返す                 | 大文字は受け付けない                           |
+| TC-F-N-04 | svgIcons.fetch を参照                               | Equivalence - normal                 | 空でない文字列で `<svg` を含む | -                                              |
+| TC-F-N-05 | svgIcons.stash を参照                               | Equivalence - normal                 | 空でない文字列で `<svg` を含む | -                                              |
+
+---
+
+## 対象: Task 3.2 スタッシュデータ取得・統合テスト
+
+### getStashes メソッド
+
+| Case ID    | Input / Precondition                                  | Perspective (Equivalence / Boundary) | Expected Result                                                                                                   | Notes                                                    |
+| ---------- | ----------------------------------------------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| TC-SD-N-01 | リポジトリに3件のスタッシュが存在                     | Equivalence - normal                 | 3件の GitStash オブジェクト配列を返す。各要素に hash, selector, baseHash, author, email, date, message が含まれる | git reflog のモック出力を使用                            |
+| TC-SD-N-02 | リポジトリにスタッシュが存在しない（refs/stash なし） | Boundary - empty                     | 空配列 `[]` を返す（エラーではない）                                                                              | git コマンドが stderr を出力するが空配列にフォールバック |
+| TC-SD-B-01 | リポジトリに1件のスタッシュのみ                       | Boundary - min (1 entry)             | 1件の GitStash オブジェクト配列を返す                                                                             | 最小有効件数                                             |
+| TC-SD-A-01 | git reflog コマンドが異常終了                         | Equivalence - error                  | 空配列を返すかエラーをスローする（設計に依存）                                                                    | spawn のモックで exit code 非0 をシミュレート            |
+| TC-SD-B-02 | reflog 出力にフィールド数不正の行が混在               | Boundary - malformed input           | 不正行はスキップされ、有効行のみパースされる                                                                      | STASH_FORMAT_FIELD_COUNT ガード条件                      |
+| TC-SD-B-03 | reflog 出力に親ハッシュが空の行が混在                 | Boundary - empty parent              | 空親行はスキップされ、有効行のみパースされる                                                                      | line[1] === "" ガード条件                                |
+
+### スタッシュ統合ロジック（getCommits 内）
+
+| Case ID    | Input / Precondition                                                  | Perspective (Equivalence / Boundary) | Expected Result                                                      | Notes                                |
+| ---------- | --------------------------------------------------------------------- | ------------------------------------ | -------------------------------------------------------------------- | ------------------------------------ |
+| TC-SI-N-01 | スタッシュの hash がコミット配列内の hash と一致                      | Equivalence - normal                 | 該当コミットノードに stash 情報がアタッチされる                      | hash-to-index ルックアップマップ使用 |
+| TC-SI-N-02 | スタッシュの baseHash がコミット配列内の hash と一致（hash は不一致） | Equivalence - normal                 | ベースコミットの直後にスタッシュ行が挿入される                       | 新規コミットノードとして挿入         |
+| TC-SI-N-03 | スタッシュの hash も baseHash もコミット配列内に不在                  | Equivalence - out of range           | スタッシュはスキップされ、コミット配列は変更なし                     | 可視範囲外のスタッシュ               |
+| TC-SI-N-04 | 同一 baseHash に2件のスタッシュ（日付: 新 > 旧）                      | Equivalence - multiple               | 新しいスタッシュが先（上）、古いスタッシュが後（下）の順で挿入される | 日付降順ソート                       |
+| TC-SI-B-02 | スタッシュ 0 件                                                       | Boundary - zero                      | コミット配列がそのまま返される（変更なし）                           | getStashes が空配列を返すケース      |
+| TC-SI-N-05 | 3件のスタッシュがそれぞれ異なる baseHash を持つ                       | Equivalence - normal                 | 各 baseHash の直後にそれぞれ挿入される                               | 逆順挿入でインデックス整合性を維持   |
+
+---
+
+## 対象: Task 3.4 スタッシュ描画テスト（行構成・グラフ頂点ロジック）
+
+| Case ID    | Input / Precondition                       | Perspective (Equivalence / Boundary) | Expected Result                                              | Notes                         |
+| ---------- | ------------------------------------------ | ------------------------------------ | ------------------------------------------------------------ | ----------------------------- |
+| TC-SR-N-01 | commit.stash !== null のコミットノード     | Equivalence - normal                 | 行要素の CSS クラスに `"commit"` と `"stash"` が両方含まれる | -                             |
+| TC-SR-N-02 | commit.stash.selector が `"stash@{0}"`     | Equivalence - normal                 | ラベルに `"@{0}"` が表示される（"stash" プレフィックス除去） | selector.substring(5)         |
+| TC-SR-N-03 | commit.stash.selector が `"stash@{12}"`    | Boundary - multi-digit index         | ラベルに `"@{12}"` が表示される                              | 2桁インデックス               |
+| TC-SR-N-04 | commit.stash !== null のコミットノード     | Equivalence - normal                 | data-hash 属性にスタッシュのコミットハッシュが設定される     | -                             |
+| TC-SR-N-05 | commit.stash === null の通常コミットノード | Equivalence - normal (non-stash)     | 行要素の CSS クラスに `"stash"` が含まれない                 | 既存動作が維持される          |
+| TC-SR-N-06 | スタッシュコミットの頂点描画               | Equivalence - normal                 | 二重円が描画される（外側: 塗りつぶし、内側: リング）         | graph.ts の描画パラメータ検証 |
+| TC-SR-N-07 | 非スタッシュコミットの頂点描画             | Equivalence - normal (non-stash)     | 単一円が描画される（既存動作維持）                           | -                             |
+
+---
+
+## 対象: Task 4.2 バックエンドスタッシュコマンドテスト
+
+### DataSource メソッド
+
+| Case ID    | Input / Precondition                            | Perspective (Equivalence / Boundary) | Expected Result                                           | Notes                   |
+| ---------- | ----------------------------------------------- | ------------------------------------ | --------------------------------------------------------- | ----------------------- |
+| TC-BS-N-01 | applyStash(repo, "stash@{0}", false)            | Equivalence - normal                 | git args: `["stash", "apply", "stash@{0}"]`               | reinstateIndex = false  |
+| TC-BS-N-02 | applyStash(repo, "stash@{0}", true)             | Equivalence - with option            | git args: `["stash", "apply", "--index", "stash@{0}"]`    | reinstateIndex = true   |
+| TC-BS-N-03 | popStash(repo, "stash@{1}", false)              | Equivalence - normal                 | git args: `["stash", "pop", "stash@{1}"]`                 | reinstateIndex = false  |
+| TC-BS-N-04 | popStash(repo, "stash@{1}", true)               | Equivalence - with option            | git args: `["stash", "pop", "--index", "stash@{1}"]`      | reinstateIndex = true   |
+| TC-BS-N-05 | dropStash(repo, "stash@{2}")                    | Equivalence - normal                 | git args: `["stash", "drop", "stash@{2}"]`                | -                       |
+| TC-BS-N-06 | branchFromStash(repo, "my-branch", "stash@{0}") | Equivalence - normal                 | git args: `["stash", "branch", "my-branch", "stash@{0}"]` | -                       |
+| TC-BS-A-01 | applyStash でコンフリクト発生                   | Equivalence - error                  | エラーメッセージ文字列を返す（null ではない）             | stderr からのメッセージ |
+| TC-BS-A-02 | dropStash で不正セレクタ                        | Equivalence - error                  | エラーメッセージ文字列を返す                              | 通常発生しないがガード  |
+
+### GitGraphView メッセージルーティング
+
+| Case ID    | Input / Precondition                  | Perspective (Equivalence / Boundary) | Expected Result                                   | Notes                |
+| ---------- | ------------------------------------- | ------------------------------------ | ------------------------------------------------- | -------------------- |
+| TC-BS-N-07 | RequestApplyStash メッセージ受信      | Equivalence - normal                 | DataSource.applyStash が正しい引数で呼ばれる      | mute/unmute パターン |
+| TC-BS-N-08 | RequestPopStash メッセージ受信        | Equivalence - normal                 | DataSource.popStash が正しい引数で呼ばれる        | mute/unmute パターン |
+| TC-BS-N-09 | RequestDropStash メッセージ受信       | Equivalence - normal                 | DataSource.dropStash が正しい引数で呼ばれる       | mute/unmute パターン |
+| TC-BS-N-10 | RequestBranchFromStash メッセージ受信 | Equivalence - normal                 | DataSource.branchFromStash が正しい引数で呼ばれる | mute/unmute パターン |
+
+---
+
+## 対象: Task 4.4 スタッシュコンテキストメニューテスト
+
+| Case ID    | Input / Precondition                               | Perspective (Equivalence / Boundary) | Expected Result                                                                                              | Notes                            |
+| ---------- | -------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------ | -------------------------------- |
+| TC-SC-N-01 | stash !== null のコミット行を右クリック            | Equivalence - normal                 | スタッシュ専用コンテキストメニューが表示される（Apply, Branch, Pop, Drop, セパレータ, Copy Name, Copy Hash） | 通常コミットメニューではないこと |
+| TC-SC-N-02 | メニューから "Apply Stash..." を選択               | Equivalence - normal                 | チェックボックスダイアログ（"Reinstate Index"、デフォルト false）が表示される                                | -                                |
+| TC-SC-N-03 | Apply ダイアログで Reinstate Index ON で確認       | Equivalence - with option            | applyStash メッセージが reinstateIndex: true で送信される                                                    | -                                |
+| TC-SC-N-04 | Apply ダイアログで Reinstate Index OFF で確認      | Equivalence - normal                 | applyStash メッセージが reinstateIndex: false で送信される                                                   | -                                |
+| TC-SC-N-05 | メニューから "Pop Stash..." を選択して確認         | Equivalence - normal                 | popStash メッセージが送信される                                                                              | Apply と同一ダイアログパターン   |
+| TC-SC-N-06 | メニューから "Drop Stash..." を選択                | Equivalence - normal                 | 確認ダイアログ（削除確認）が表示される                                                                       | -                                |
+| TC-SC-N-07 | Drop 確認ダイアログで確認                          | Equivalence - normal                 | dropStash メッセージが送信される                                                                             | -                                |
+| TC-SC-N-08 | メニューから "Create Branch from Stash..." を選択  | Equivalence - normal                 | 参照名入力ダイアログ（バリデーション付き）が表示される                                                       | refInvalid バリデーション        |
+| TC-SC-N-09 | Branch ダイアログで有効なブランチ名を入力して確認  | Equivalence - normal                 | branchFromStash メッセージが送信される                                                                       | -                                |
+| TC-SC-N-10 | メニューから "Copy Stash Name to Clipboard" を選択 | Equivalence - normal                 | copyToClipboard メッセージが type: "Stash Name", data: selector で送信される                                 | ダイアログなし                   |
+| TC-SC-N-11 | メニューから "Copy Stash Hash to Clipboard" を選択 | Equivalence - normal                 | copyToClipboard メッセージが type: "Stash Hash", data: hash で送信される                                     | ダイアログなし                   |
+
+---
+
+## 対象: Task 5.2 バックエンド Uncommitted コマンドテスト
+
+### DataSource メソッド
+
+| Case ID    | Input / Precondition                      | Perspective (Equivalence / Boundary)  | Expected Result                                                                  | Notes                                      |
+| ---------- | ----------------------------------------- | ------------------------------------- | -------------------------------------------------------------------------------- | ------------------------------------------ |
+| TC-BU-N-01 | pushStash(repo, "WIP message", true)      | Equivalence - normal (full options)   | git args: `["stash", "push", "--message", "WIP message", "--include-untracked"]` | メッセージ + untracked                     |
+| TC-BU-N-02 | pushStash(repo, "WIP message", false)     | Equivalence - normal (message only)   | git args: `["stash", "push", "--message", "WIP message"]`                        | メッセージのみ                             |
+| TC-BU-N-03 | pushStash(repo, "", true)                 | Equivalence - normal (untracked only) | git args: `["stash", "push", "--include-untracked"]`                             | --message フラグなし                       |
+| TC-BU-B-01 | pushStash(repo, "", false)                | Boundary - minimal args               | git args: `["stash", "push"]`                                                    | オプションなし                             |
+| TC-BU-N-04 | resetUncommitted(repo, "mixed")           | Equivalence - normal                  | git args: `["reset", "--mixed", "HEAD"]`                                         | -                                          |
+| TC-BU-N-05 | resetUncommitted(repo, "hard")            | Equivalence - normal                  | git args: `["reset", "--hard", "HEAD"]`                                          | -                                          |
+| TC-BU-A-01 | resetUncommitted(repo, "soft")            | Equivalence - invalid mode            | エラーまたは拒否される                                                           | VALID_UNCOMMITTED_RESET_MODES に含まれない |
+| TC-BU-A-02 | resetUncommitted(repo, "invalid")         | Equivalence - invalid mode            | エラーまたは拒否される                                                           | 不正な文字列                               |
+| TC-BU-A-03 | resetUncommitted(repo, "")                | Boundary - empty                      | エラーまたは拒否される                                                           | 空文字列                                   |
+| TC-BU-N-06 | cleanUntrackedFiles(repo, false)          | Equivalence - normal                  | git args: `["clean", "-f"]`                                                      | ディレクトリ除外                           |
+| TC-BU-N-07 | cleanUntrackedFiles(repo, true)           | Equivalence - with option             | git args: `["clean", "-f", "-d"]`                                                | ディレクトリ含む                           |
+| TC-BU-A-04 | pushStash で git コマンドが失敗           | Equivalence - error                   | エラーメッセージ文字列を返す（null ではない）                                    | stderr からのメッセージ                    |
+| TC-BU-A-05 | cleanUntrackedFiles で git コマンドが失敗 | Equivalence - error                   | エラーメッセージ文字列を返す（null ではない）                                    | stderr からのメッセージ                    |
+
+### GitGraphView メッセージルーティング
+
+| Case ID    | Input / Precondition                      | Perspective (Equivalence / Boundary) | Expected Result                                       | Notes                |
+| ---------- | ----------------------------------------- | ------------------------------------ | ----------------------------------------------------- | -------------------- |
+| TC-BU-N-08 | RequestPushStash メッセージ受信           | Equivalence - normal                 | DataSource.pushStash が正しい引数で呼ばれる           | mute/unmute パターン |
+| TC-BU-N-09 | RequestResetUncommitted メッセージ受信    | Equivalence - normal                 | DataSource.resetUncommitted が正しい引数で呼ばれる    | mute/unmute パターン |
+| TC-BU-N-10 | RequestCleanUntrackedFiles メッセージ受信 | Equivalence - normal                 | DataSource.cleanUntrackedFiles が正しい引数で呼ばれる | mute/unmute パターン |
+
+---
+
+## 対象: Task 5.4 Uncommitted Changes コンテキストメニューテスト
+
+| Case ID    | Input / Precondition                                            | Perspective (Equivalence / Boundary) | Expected Result                                                                           | Notes                |
+| ---------- | --------------------------------------------------------------- | ------------------------------------ | ----------------------------------------------------------------------------------------- | -------------------- |
+| TC-UC-N-01 | Uncommitted Changes 行を右クリック                              | Equivalence - normal                 | Uncommitted 専用コンテキストメニューが表示される（Stash, Reset, Clean）                   | -                    |
+| TC-UC-N-02 | メニューから "Stash uncommitted changes..." を選択              | Equivalence - normal                 | フォームダイアログ（メッセージ入力 + Include Untracked チェックボックス）が表示される     | -                    |
+| TC-UC-N-03 | Stash ダイアログでメッセージ入力 + Include Untracked ON で確認  | Equivalence - normal                 | pushStash メッセージが message と includeUntracked: true で送信される                     | -                    |
+| TC-UC-N-04 | Stash ダイアログでメッセージ空欄 + Include Untracked OFF で確認 | Boundary - empty message             | pushStash メッセージが message: "" と includeUntracked: false で送信される                | --message フラグなし |
+| TC-UC-N-05 | メニューから "Reset uncommitted changes..." を選択              | Equivalence - normal                 | 選択ダイアログ（Mixed / Hard の2択）が表示される                                          | -                    |
+| TC-UC-N-06 | Reset ダイアログで Mixed を選択して確認                         | Equivalence - normal                 | resetUncommitted メッセージが mode: "mixed" で送信される                                  | -                    |
+| TC-UC-N-07 | Reset ダイアログで Hard を選択して確認                          | Equivalence - normal                 | resetUncommitted メッセージが mode: "hard" で送信される                                   | -                    |
+| TC-UC-N-08 | メニューから "Clean untracked files..." を選択                  | Equivalence - normal                 | チェックボックスダイアログ（"Clean untracked directories"、デフォルト false）が表示される | -                    |
+| TC-UC-N-09 | Clean ダイアログで directories ON で確認                        | Equivalence - with option            | cleanUntrackedFiles メッセージが directories: true で送信される                           | -                    |
+| TC-UC-N-10 | Clean ダイアログで directories OFF で確認                       | Equivalence - normal                 | cleanUntrackedFiles メッセージが directories: false で送信される                          | -                    |
+
+---
+
+## 対象: Task 6.2 フェッチ機能テスト
+
+### DataSource メソッド
+
+| Case ID    | Input / Precondition           | Perspective (Equivalence / Boundary) | Expected Result                | Notes                   |
+| ---------- | ------------------------------ | ------------------------------------ | ------------------------------ | ----------------------- |
+| TC-FT-N-01 | fetch(repo) を実行             | Equivalence - normal                 | git args: `["fetch", "--all"]` | 引数固定                |
+| TC-FT-A-01 | fetch でネットワークエラー発生 | Equivalence - error                  | エラーメッセージ文字列を返す   | stderr からのメッセージ |
+| TC-FT-N-02 | fetch 成功（status === null）  | Equivalence - normal                 | null を返す                    | GitCommandStatus 型     |
+
+### GitGraphView メッセージルーティング
+
+| Case ID    | Input / Precondition        | Perspective (Equivalence / Boundary) | Expected Result                         | Notes                |
+| ---------- | --------------------------- | ------------------------------------ | --------------------------------------- | -------------------- |
+| TC-FT-N-03 | RequestFetch メッセージ受信 | Equivalence - normal                 | DataSource.fetch が正しい引数で呼ばれる | mute/unmute パターン |
+
+### Webview フェッチボタン
+
+| Case ID    | Input / Precondition                        | Perspective (Equivalence / Boundary) | Expected Result                                          | Notes                        |
+| ---------- | ------------------------------------------- | ------------------------------------ | -------------------------------------------------------- | ---------------------------- |
+| TC-FT-N-04 | フェッチボタンをクリック                    | Equivalence - normal                 | fetch メッセージが currentRepo を含んで送信される        | postMessage 呼び出し検証     |
+| TC-FT-N-05 | fetch レスポンス status === null            | Equivalence - normal                 | グラフが自動リフレッシュされる（refresh(true) 呼び出し） | -                            |
+| TC-FT-A-02 | fetch レスポンス status === "error message" | Equivalence - error                  | エラーダイアログが表示される                             | showErrorDialog 呼び出し検証 |

--- a/docs/testing/perspectives/menubar-search-diff-test.md
+++ b/docs/testing/perspectives/menubar-search-diff-test.md
@@ -1,0 +1,183 @@
+# テスト観点表: メニューバー検索・差分表示
+
+> Generated: 2026-02-24T14:00:00Z
+> Updated: 2026-02-25 (不具合修正 27d2b61, 52a5aa8 反映)
+> Origin: AIDD pipeline (aidd-spec-tasks-test)
+> Spec: `notes/features/002-add-menu/`
+
+---
+
+## 対象: Task 2.2 DataSource差分取得メソッド テスト
+
+### getCommitComparison メソッド
+
+| Case ID    | Input / Precondition                             | Perspective (Equivalence / Boundary) | Expected Result                                                                            | Notes                                              |
+| ---------- | ------------------------------------------------ | ------------------------------------ | ------------------------------------------------------------------------------------------ | -------------------------------------------------- |
+| TC-DC-N-01 | fromHash: 有効なハッシュ, toHash: 有効なハッシュ | Equivalence - normal                 | GitFileChange[] を返す。各要素にoldFilePath, newFilePath, type, additions, deletionsを含む | nameStatus + numStat の並列実行                    |
+| TC-DC-N-02 | 差分にリネームファイル(R)を含む                  | Equivalence - normal                 | oldFilePath と newFilePath が異なる GitFileChange を返す                                   | --find-renames による検出                          |
+| TC-DC-N-03 | 差分にA/M/D/R全種を含む                          | Equivalence - normal                 | 各変更種別が正しく分類される                                                               | --diff-filter=AMDR                                 |
+| TC-DC-N-04 | numStat の追加行数・削除行数                     | Equivalence - normal                 | additions, deletions に正しい数値が設定される                                              | numStat パースの検証                               |
+| TC-DC-B-01 | toHash: 空文字（作業ツリー比較）                 | Boundary - empty toHash              | git diff引数にtoHashが含まれない。作業ツリーとの差分を返す。ls-filesも実行される           | REQ-2.9 作業ツリー比較。isToWorkingTree=true       |
+| TC-DC-B-02 | fromHash: UNCOMMITTED_CHANGES_HASH ("\*")        | Boundary - special hash              | toHashがdiffベースとして使用される（作業ツリー比較）。git diff引数にtoHashのみ含まれる     | UNCOMMITTED特殊処理。旧: HEAD置換→新: toHashベース |
+| TC-DC-B-03 | 変更ファイルが0件                                | Boundary - empty result              | 空配列 [] を返す（nullではない）                                                           | 同一コミット間 or 差分なし                         |
+| TC-DC-A-01 | git diffコマンドがエラー終了                     | Equivalence - error                  | null を返す                                                                                | spawn例外時にcatchブロックでnull返却               |
+| TC-DC-A-02 | numStatの出力行がnameStatusと不一致              | Boundary - malformed                 | 取得可能なデータのみで結果を構成する                                                       | パースの堅牢性                                     |
+
+### getCommitComparison 未追跡ファイル統合（不具合修正 27d2b61 追加分）
+
+| Case ID    | Input / Precondition                                   | Perspective (Equivalence / Boundary) | Expected Result                                                                        | Notes                                             |
+| ---------- | ------------------------------------------------------ | ------------------------------------ | -------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| TC-DC-N-05 | fromHash=UNCOMMITTED_CHANGES_HASH + 未追跡ファイルあり | Equivalence - normal                 | ls-filesが実行され、結果にtype:"A"、additions/deletions:nullの未追跡ファイルが含まれる | isToWorkingTree=true時のみls-files実行            |
+| TC-DC-N-06 | toHash="" (作業ツリー比較) + 未追跡ファイルあり        | Equivalence - normal                 | ls-filesが実行され、結果に未追跡ファイルが含まれる                                     | toHash空文字でもisToWorkingTree=true              |
+| TC-DC-B-04 | 2コミット間比較（fromHash, toHash共に有効ハッシュ）    | Boundary - no ls-files               | ls-filesは実行されない（spawn呼び出しは2回: nameStatus + numStatのみ）                 | isToWorkingTree=false                             |
+| TC-DC-B-05 | 作業ツリー比較 + 未追跡ファイルがdiff出力と重複        | Boundary - dedup                     | 重複ファイルは1回のみ含まれる（fileLookupで既存エントリをスキップ）                    | `typeof fileLookup[filePath] === "number"` ガード |
+| TC-DC-B-06 | 作業ツリー比較 + 未追跡ファイル0件（ls-files出力が空） | Boundary - empty untracked           | diff出力のみで結果が構成される（untrackedFiles配列が空）                               | -                                                 |
+| TC-DC-B-07 | 作業ツリー比較 + ls-files出力に空行が混在              | Boundary - empty line                | 空行はスキップされ、有効なファイルパスのみ追加される                                   | `filePath === ""` ガード                          |
+
+### getUncommittedDetails メソッド（不具合修正 27d2b61 追加分）
+
+| Case ID    | Input / Precondition                        | Perspective (Equivalence / Boundary) | Expected Result                                                                                  | Notes                                             |
+| ---------- | ------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------ | ------------------------------------------------- |
+| TC-UD-N-01 | staged/unstaged変更 + 未追跡ファイルあり    | Equivalence - normal                 | fileChangesにdiff結果 + 未追跡ファイル(type:"A", additions/deletions:null)が含まれる             | nameStatus + numStat + ls-filesの3並列実行        |
+| TC-UD-N-02 | staged/unstaged変更のみ、未追跡ファイルなし | Equivalence - normal                 | fileChangesにdiff結果のみ含まれる（ls-files出力が空）                                            | -                                                 |
+| TC-UD-B-01 | diff出力なし、未追跡ファイルのみ存在        | Boundary - diff empty                | fileChangesに未追跡ファイルのみ含まれる（type:"A", additions/deletions:null）                    | -                                                 |
+| TC-UD-B-02 | 未追跡ファイルがdiff結果のnewFilePathと重複 | Boundary - dedup                     | 重複ファイルは1回のみ含まれる（fileLookupで既存エントリをスキップ）                              | `typeof fileLookup[filePath] === "number"` ガード |
+| TC-UD-B-03 | ls-files出力に空行が混在                    | Boundary - empty line                | 空行はスキップされ、有効なファイルパスのみ追加される                                             | `filePath === ""` ガード                          |
+| TC-UD-A-01 | git diff または ls-files が例外をスロー     | Equivalence - error                  | null を返す                                                                                      | catch ブロックでnull返却                          |
+| TC-UD-N-03 | 正常なdiff出力（リネーム含む）              | Equivalence - normal                 | GitCommitDetails を返す。hash=UNCOMMITTED_CHANGES_HASH、fileChangesに正しいtype/pathが設定される | nameStatus パースの基本検証                       |
+
+---
+
+## 対象: Task 2.4 Extension メッセージルーティング テスト
+
+### GitGraphView compareCommits メッセージハンドラー
+
+| Case ID    | Input / Precondition                                           | Perspective (Equivalence / Boundary) | Expected Result                                                                     | Notes |
+| ---------- | -------------------------------------------------------------- | ------------------------------------ | ----------------------------------------------------------------------------------- | ----- |
+| TC-MR-N-01 | RequestCompareCommits メッセージ受信（有効なfromHash, toHash） | Equivalence - normal                 | DataSource.getCommitComparison() が repo, fromHash, toHash で呼ばれる               | -     |
+| TC-MR-N-02 | getCommitComparison() が GitFileChange[] を返す                | Equivalence - normal                 | ResponseCompareCommits が fileChanges, fromHash, toHash を含んでwebviewに送信される | -     |
+| TC-MR-A-01 | getCommitComparison() が null を返す                           | Equivalence - error                  | ResponseCompareCommits の fileChanges が null でwebviewに送信される                 | -     |
+
+### viewDiff 比較モード拡張
+
+| Case ID    | Input / Precondition                                 | Perspective (Equivalence / Boundary) | Expected Result                                                     | Notes                  |
+| ---------- | ---------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------- | ---------------------- |
+| TC-MR-N-03 | RequestViewDiff に compareWithHash あり              | Equivalence - normal                 | encodeDiffDocUri で fromHash と toHash を使った2つのURIが生成される | 2点間比較用Diff Editor |
+| TC-MR-N-04 | RequestViewDiff に compareWithHash なし（undefined） | Equivalence - normal                 | 既存の動作（親コミットとの差分）が維持される                        | 後方互換               |
+
+---
+
+## 対象: Task 3.3 FindWidget テスト
+
+### DOM生成・表示管理
+
+| Case ID    | Input / Precondition          | Perspective (Equivalence / Boundary) | Expected Result                                                                         | Notes |
+| ---------- | ----------------------------- | ------------------------------------ | --------------------------------------------------------------------------------------- | ----- |
+| TC-FW-N-01 | FindWidget コンストラクタ実行 | Equivalence - normal                 | DOM構造が生成される: 入力欄, Aaトグル, .\*トグル, カウンター, 前/次ボタン, 閉じるボタン | -     |
+| TC-FW-N-02 | show() 呼び出し               | Equivalence - normal                 | ウィジェットが表示状態になり、入力欄にフォーカスが移動する                              | -     |
+| TC-FW-N-03 | close() 呼び出し              | Equivalence - normal                 | ウィジェットが非表示になり、全ハイライトがクリアされる                                  | -     |
+| TC-FW-N-04 | show() 後に isVisible()       | Equivalence - normal                 | true を返す                                                                             | -     |
+| TC-FW-N-05 | close() 後に isVisible()      | Equivalence - normal                 | false を返す                                                                            | -     |
+
+### 入力制御
+
+| Case ID    | Input / Precondition            | Perspective (Equivalence / Boundary) | Expected Result              | Notes                |
+| ---------- | ------------------------------- | ------------------------------------ | ---------------------------- | -------------------- |
+| TC-FW-N-06 | setInputEnabled(false)          | Equivalence - normal                 | 入力欄がdisabled状態になる   | データロード前       |
+| TC-FW-N-07 | setInputEnabled(true)           | Equivalence - normal                 | 入力欄がenabled状態になる    | データロード完了後   |
+| TC-FW-B-01 | コミット0件の状態でテキスト入力 | Boundary - zero commits              | マッチなし、カウンター非表示 | disabled状態の可能性 |
+
+### 検索マッチング
+
+| Case ID    | Input / Precondition                                                   | Perspective (Equivalence / Boundary) | Expected Result                                        | Notes       |
+| ---------- | ---------------------------------------------------------------------- | ------------------------------------ | ------------------------------------------------------ | ----------- |
+| TC-FW-N-08 | テキスト "fix" 入力、コミットメッセージに "fix bug" を含むコミットあり | Equivalence - normal                 | 該当コミット行がハイライトされ、カウンターが更新される | -           |
+| TC-FW-N-09 | テキスト入力、著者名にマッチするコミットあり                           | Equivalence - normal                 | 著者名欄がハイライトされる                             | -           |
+| TC-FW-N-10 | テキスト入力、コミットハッシュ（短縮形）にマッチ                       | Equivalence - normal                 | ハッシュ欄がハイライトされる                           | -           |
+| TC-FW-N-11 | テキスト入力、ブランチ名・タグ名にマッチ                               | Equivalence - normal                 | ブランチ/タグラベル欄がハイライトされる                | -           |
+| TC-FW-N-12 | テキスト入力で3件マッチ                                                | Equivalence - normal                 | カウンターが "1 of 3" と表示される                     | 初期位置は1 |
+| TC-FW-B-02 | テキスト入力でマッチ0件                                                | Boundary - no matches                | カウンターが "No Results" と表示、ハイライトなし       | -           |
+| TC-FW-B-03 | テキスト入力でマッチ1件                                                | Boundary - single match              | カウンターが "1 of 1" と表示される                     | -           |
+| TC-FW-B-04 | 検索テキストを空にクリア                                               | Boundary - empty text                | 全ハイライトが除去され、カウンターが非表示になる       | -           |
+
+### 検索オプション
+
+| Case ID    | Input / Precondition                     | Perspective (Equivalence / Boundary) | Expected Result                                 | Notes                                      |
+| ---------- | ---------------------------------------- | ------------------------------------ | ----------------------------------------------- | ------------------------------------------ | ---------------- |
+| TC-FW-N-13 | caseSensitive OFF, テキスト "Fix"        | Equivalence - normal                 | "fix", "Fix", "FIX" 全てにマッチ                | デフォルト動作                             |
+| TC-FW-N-14 | caseSensitive ON, テキスト "Fix"         | Equivalence - normal                 | "Fix" のみにマッチ、"fix" にはマッチしない      | RegExp iフラグなし                         |
+| TC-FW-N-15 | regex ON, テキスト "fix                  | feat"                                | Equivalence - normal                            | "fix" または "feat" を含むコミットにマッチ | 正規表現パターン |
+| TC-FW-A-01 | regex ON, テキスト "[invalid"            | Equivalence - error                  | エラー属性が設定され（赤枠）、マッチなし        | RegExp コンストラクタ例外                  |
+| TC-FW-A-02 | regex ON, テキスト "(?:)" (ゼロ長マッチ) | Boundary - zero-length               | エラー属性が設定され、マッチがクリアされる      | ReDoS防止                                  |
+| TC-FW-A-03 | regex ON, テキスト "(a+)+" (潜在的ReDoS) | Boundary - backtracking              | try-catchで安全に処理される（クラッシュしない） | ReDoS防止                                  |
+
+### ナビゲーション
+
+| Case ID    | Input / Precondition         | Perspective (Equivalence / Boundary) | Expected Result                                   | Notes      |
+| ---------- | ---------------------------- | ------------------------------------ | ------------------------------------------------- | ---------- |
+| TC-FW-N-16 | 3件マッチ、位置1、next()     | Equivalence - normal                 | 位置が2に移動し、カウンターが "2 of 3" になる     | -          |
+| TC-FW-N-17 | 3件マッチ、位置1、prev()     | Equivalence - normal                 | 位置が3に循環移動し、カウンターが "3 of 3" になる | 逆方向循環 |
+| TC-FW-B-05 | 3件マッチ、位置3、next()     | Boundary - wrap forward              | 位置が1に循環移動し、カウンターが "1 of 3" になる | 順方向循環 |
+| TC-FW-B-06 | マッチ0件で next()           | Boundary - no matches                | 何も起こらない（エラーにならない）                | -          |
+| TC-FW-N-18 | ナビゲーション後のスクロール | Equivalence - normal                 | scrollToCommit() が呼び出される                   | -          |
+
+### 状態永続化
+
+| Case ID    | Input / Precondition              | Perspective (Equivalence / Boundary) | Expected Result                                                                        | Notes |
+| ---------- | --------------------------------- | ------------------------------------ | -------------------------------------------------------------------------------------- | ----- |
+| TC-FW-N-19 | getState() 呼び出し               | Equivalence - normal                 | FindWidgetState オブジェクトを返す（text, currentHash, visible, caseSensitive, regex） | -     |
+| TC-FW-N-20 | restoreState(savedState) 呼び出し | Equivalence - normal                 | 保存した状態が正しく復元される（テキスト、トグル、表示状態）                           | -     |
+| TC-FW-B-07 | restoreState(null)                | Boundary - null state                | デフォルト状態が適用される（エラーにならない）                                         | -     |
+
+### デバウンス
+
+| Case ID    | Input / Precondition          | Perspective (Equivalence / Boundary) | Expected Result                                                     | Notes              |
+| ---------- | ----------------------------- | ------------------------------------ | ------------------------------------------------------------------- | ------------------ |
+| TC-FW-N-21 | テキスト入力後200ms経過       | Equivalence - normal                 | 検索が実行される                                                    | SEARCH_DEBOUNCE_MS |
+| TC-FW-B-08 | テキスト入力後100msで別の入力 | Boundary - debounce reset            | 最初の検索はキャンセルされ、新しい入力から200ms後に検索が実行される | -                  |
+
+---
+
+## 対象: Task 4.3 Frontend統合テスト
+
+### 比較モード状態遷移
+
+| Case ID    | Input / Precondition                               | Perspective (Equivalence / Boundary) | Expected Result                                                                                                        | Notes                                                |
+| ---------- | -------------------------------------------------- | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| TC-FI-N-01 | 通常クリック（修飾キーなし）                       | Equivalence - normal                 | コミット詳細表示（既存動作維持）                                                                                       | -                                                    |
+| TC-FI-N-02 | expandedCommit あり + 別コミットをCtrl+クリック    | Equivalence - normal                 | 比較モードに遷移。getCommitOrderにより古いコミット(テーブル下位)がfromHash、新しいコミットがtoHashでcompareCommits送信 | 不具合修正52a5aa8: 順序保証追加                      |
+| TC-FI-N-03 | 比較モード + 同じ比較対象をCtrl+クリック           | Equivalence - normal                 | 比較モード解除、compareWithHash が null に戻る                                                                         | -                                                    |
+| TC-FI-N-04 | 比較モード + 別のコミットをCtrl+クリック           | Equivalence - normal                 | 比較対象が変更される。getCommitOrderにより古いコミットがfromHashでcompareCommits送信                                   | 不具合修正52a5aa8: 順序保証追加                      |
+| TC-FI-N-05 | 比較モード + 通常クリック（修飾キーなし）          | Equivalence - normal                 | 比較解除 + 新しいコミットの詳細表示                                                                                    | -                                                    |
+| TC-FI-B-01 | expandedCommit なし + Ctrl+クリック                | Boundary - no expanded               | 通常の詳細表示（比較モードにならない）                                                                                 | REQ-2.7制約                                          |
+| TC-FI-B-02 | 未コミット変更行展開中 + コミット行をCtrl+クリック | Boundary - uncommitted expanded      | compareCommitsメッセージがfromHash=UNCOMMITTED_CHANGES_HASH, toHash=コミットハッシュで送信される                       | getCommitOrderがUNCOMMITTED_CHANGES_HASHをfromに固定 |
+
+### 未コミット変更行Ctrl+クリック比較（不具合修正 52a5aa8 追加分）
+
+| Case ID    | Input / Precondition                                       | Perspective (Equivalence / Boundary) | Expected Result                                                                                                  | Notes                                                |
+| ---------- | ---------------------------------------------------------- | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| TC-FI-N-12 | コミット展開中 + 未コミット変更行をCtrl+クリック           | Equivalence - normal                 | 比較モードに遷移。compareCommitsメッセージがfromHash=UNCOMMITTED_CHANGES_HASH, toHash=展開中コミットで送信される | getCommitOrderがUNCOMMITTED_CHANGES_HASHをfromに固定 |
+| TC-FI-N-13 | 未コミット変更行と比較中 + 同じ未コミット行をCtrl+クリック | Equivalence - toggle off             | 比較モード解除。compareWithHash=null、compareWithSrcElem=null。元のコミット詳細が再表示される                    | -                                                    |
+| TC-FI-N-14 | 未コミット変更行の通常クリック（展開済みコミットなし）     | Equivalence - normal (non-modifier)  | 通常のcommitDetails要求が送信される（比較モードにならない）                                                      | 既存動作維持                                         |
+
+### 比較レスポンス処理
+
+| Case ID    | Input / Precondition                                                               | Perspective (Equivalence / Boundary) | Expected Result                                                               | Notes                                                                |
+| ---------- | ---------------------------------------------------------------------------------- | ------------------------------------ | ----------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| TC-FI-N-06 | ResponseCompareCommits 受信（fileChanges あり）                                    | Equivalence - normal                 | 比較ヘッダー表示、ファイル一覧表示                                            | -                                                                    |
+| TC-FI-A-01 | ResponseCompareCommits 受信（fileChanges: null）                                   | Equivalence - error                  | showErrorDialog が呼ばれる                                                    | -                                                                    |
+| TC-FI-N-07 | 比較モードでファイルクリック                                                       | Equivalence - normal                 | viewDiff メッセージに compareWithHash が含まれる                              | -                                                                    |
+| TC-FI-N-15 | ResponseCompareCommitsのfromHash/toHashがexpandedCommit.hash/compareWithHashと逆順 | Equivalence - reorder tolerance      | 正しく表示される（セット比較で順序不問。hashes Setに両方含まれていれば有効）  | 不具合修正52a5aa8: getCommitOrderによる順序変更対応                  |
+| TC-FI-N-16 | 未コミット変更行展開中にloadCommits受信（テーブル再描画）                          | Equivalence - re-render              | srcElemが`.commit, .unsavedChanges`セレクタで再取得され、展開状態が維持される | 不具合修正27d2b61: セレクタ拡張 `.commit`→`.commit, .unsavedChanges` |
+
+### FindWidget統合
+
+| Case ID    | Input / Precondition                              | Perspective (Equivalence / Boundary) | Expected Result                                               | Notes    |
+| ---------- | ------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------- | -------- |
+| TC-FI-N-08 | Ctrl/Cmd+F キー押下                               | Equivalence - normal                 | FindWidget.show() が呼ばれる                                  | -        |
+| TC-FI-N-09 | 検索ボタンクリック                                | Equivalence - normal                 | FindWidget.show() が呼ばれる                                  | -        |
+| TC-FI-N-10 | saveState() 呼び出し                              | Equivalence - normal                 | findWidgetState が WebViewState に含まれる                    | -        |
+| TC-FI-N-11 | restoreState (findWidgetState あり)               | Equivalence - normal                 | FindWidget.restoreState() が呼ばれる                          | -        |
+| TC-FI-B-03 | restoreState (findWidgetState なし、旧バージョン) | Boundary - backward compat           | FindWidget がデフォルト状態で初期化される（エラーにならない） | 後方互換 |
+
+---

--- a/media/main.css
+++ b/media/main.css
@@ -2,6 +2,9 @@
 body {
   margin: 0;
   padding: 0;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
 }
 body.unableToLoad {
   margin: 0 20px;
@@ -11,9 +14,9 @@ body.unableToLoad p {
   text-align: center;
 }
 #scrollShadow.active {
-  position: fixed;
-  top: 0px;
-  left: 0px;
+  position: sticky;
+  top: 0;
+  left: 0;
   width: 100%;
   height: 0px;
   box-shadow: 0 -6px 6px 6px var(--vscode-scrollbar-shadow);
@@ -37,10 +40,14 @@ body.unableToLoad p {
   fill: var(--vscode-editor-background);
   stroke-width: 2;
 }
-#commitGraph circle:not(.current) {
+#commitGraph circle:not(.current):not(.stashInner) {
   stroke: var(--vscode-editor-background);
   stroke-width: 1;
   stroke-opacity: 0.75;
+}
+#commitGraph circle.stashInner {
+  fill: var(--vscode-editor-background);
+  stroke-width: 1.5;
 }
 #commitGraph path.shaddow {
   fill: none;
@@ -75,12 +82,17 @@ body.unableToLoad p {
   overflow: hidden;
 }
 #commitTable tr.commit:hover td,
+#commitTable tr.unsavedChanges:hover td,
 #commitTable tr.commit.contextMenuActive td,
+#commitTable tr.unsavedChanges.contextMenuActive td,
 #commitTable tr.commit.dialogActive td,
-#commitTable tr.commit.commitDetailsOpen td {
+#commitTable tr.unsavedChanges.dialogActive td,
+#commitTable tr.commit.commitDetailsOpen td,
+#commitTable tr.unsavedChanges.commitDetailsOpen td {
   background-color: rgba(128, 128, 128, 0.15);
 }
-#commitTable tr.commit:hover td {
+#commitTable tr.commit:hover td,
+#commitTable tr.unsavedChanges:hover td {
   cursor: pointer;
 }
 #commitTable td {
@@ -109,7 +121,10 @@ body.unableToLoad p {
   cursor: col-resize;
 }
 .tableColHeader {
-  position: relative;
+  position: sticky;
+  top: 0;
+  z-index: 11;
+  background-color: var(--vscode-editor-background);
 }
 .resizeCol {
   position: absolute;
@@ -361,6 +376,17 @@ svg.fileIcon {
   background-color: rgba(128, 128, 128, 0.1);
 }
 
+/* Stash */
+#commitTable tr.commit.stash td {
+  font-style: italic;
+}
+.gitRef.stash {
+  border-color: rgba(128, 128, 128, 0.5);
+}
+.gitRef.stash > svg {
+  background-color: rgba(128, 128, 128, 0.6);
+}
+
 /* Loader */
 #loadingHeader {
   text-align: center;
@@ -389,12 +415,20 @@ svg.fileIcon {
   left: 0;
   right: 0;
   top: 0;
-  padding: 4px 96px 4px 0;
+  z-index: 12;
+  background-color: var(--vscode-editor-background);
+  padding: 4px 104px 4px 0;
   border-bottom: 1px solid rgba(128, 128, 128, 0.5);
   line-height: 32px;
   text-align: center;
   font-weight: 700;
   font-size: 13px;
+  flex-shrink: 0;
+}
+#scrollContainer {
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
 }
 #repoControl,
 #branchControl,
@@ -410,15 +444,93 @@ svg.fileIcon {
   width: 14px;
   vertical-align: text-top;
 }
+#searchBtn,
+#fetchBtn,
+#currentBtn,
 #refreshBtn {
   position: absolute;
-  right: 8px;
   top: 50%;
-  width: 80px;
-  height: 22px;
-  line-height: 22px;
-  border-radius: 11px;
-  margin-top: -12px;
+  width: 20px;
+  height: 20px;
+  margin-top: -10px;
+  cursor: pointer;
+  user-select: none;
+}
+#searchBtn {
+  right: 82px;
+}
+#fetchBtn {
+  right: 58px;
+}
+#currentBtn {
+  right: 34px;
+}
+#refreshBtn {
+  right: 10px;
+}
+#searchBtn svg,
+#fetchBtn svg,
+#currentBtn svg,
+#refreshBtn svg {
+  position: absolute;
+  fill: var(--vscode-editor-foreground);
+  opacity: 0.8;
+  stroke: var(--vscode-editor-foreground);
+  stroke-opacity: 0.5;
+  stroke-width: 0;
+}
+#searchBtn svg {
+  left: 2px;
+  top: 2px;
+  width: 16px !important;
+  height: 16px !important;
+}
+#fetchBtn svg {
+  left: 2px;
+  top: 2px;
+  width: 16px !important;
+  height: 16px !important;
+}
+#currentBtn svg {
+  left: 1px;
+  top: 1px;
+  width: 18px !important;
+  height: 18px !important;
+  stroke-width: 0.5px;
+}
+#refreshBtn svg {
+  left: 2px;
+  top: 2px;
+  width: 16px !important;
+  height: 16px !important;
+}
+#searchBtn:hover svg,
+#fetchBtn:hover svg,
+#currentBtn:hover svg,
+#refreshBtn:hover svg {
+  opacity: 1;
+  stroke-width: 0.5px;
+}
+#currentBtn:hover svg {
+  stroke-width: 1px;
+}
+#refreshBtn.refreshing {
+  cursor: default;
+}
+#refreshBtn.refreshing svg {
+  left: 3.25px;
+  top: 2px;
+  width: 13.5px !important;
+  height: 18px !important;
+  animation: loadingIconAnimation 2s linear infinite;
+}
+#currentBtn.disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+#currentBtn.disabled:hover svg {
+  opacity: 0.8;
+  stroke-width: 0.5px;
 }
 #loadMoreCommitsBtn {
   width: 180px;
@@ -485,7 +597,7 @@ svg.fileIcon {
   text-align: center;
   max-width: 360px;
   max-height: 80%;
-  z-index: 10;
+  z-index: 20;
   box-shadow: 0 0 30px 5px var(--vscode-widget-shadow);
   overflow-y: auto;
 }
@@ -551,7 +663,7 @@ svg.fileIcon {
   right: 0;
   top: 0;
   bottom: 0;
-  z-index: 9;
+  z-index: 19;
 }
 #dialog.noInput #dialogAction,
 #dialog.inputInvalid #dialogAction {
@@ -596,6 +708,172 @@ svg.fileIcon {
 }
 .roundedBtn:hover {
   background-color: rgba(128, 128, 128, 0.2);
+}
+
+/* Flash animation for scroll-to-current */
+#commitTable tr.commit.flash td {
+  animation: flash-commit 0.75s linear;
+}
+@keyframes flash-commit {
+  0% {
+    background-color: transparent;
+  }
+  20% {
+    background-color: rgba(128, 128, 128, 0.4);
+  }
+  35% {
+    background-color: rgba(128, 128, 128, 0.15);
+  }
+  50% {
+    background-color: rgba(128, 128, 128, 0.35);
+  }
+  65% {
+    background-color: rgba(128, 128, 128, 0.25);
+  }
+  100% {
+    background-color: transparent;
+  }
+}
+
+/* Compare Target */
+#commitTable tr.commit.compareTarget td {
+  background-color: rgba(255, 167, 36, 0.15);
+}
+#commitTable tr.commit.compareTarget:hover td {
+  background-color: rgba(255, 167, 36, 0.25);
+}
+
+/* Find Match Highlight */
+#commitTable tr.commit.findMatch td {
+  background-color: rgba(234, 92, 0, 0.1);
+}
+#commitTable tr.commit.findCurrentCommit td {
+  background-color: rgba(234, 92, 0, 0.25);
+}
+
+/* FindWidget */
+.findWidget {
+  position: fixed;
+  top: 0;
+  right: 24px;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 4px;
+  background-color: var(--vscode-editorWidget-background, var(--vscode-editor-background));
+  border: 1px solid var(--vscode-editorWidget-border, rgba(128, 128, 128, 0.5));
+  border-top: none;
+  border-radius: 0 0 4px 4px;
+  box-shadow: 0 2px 8px var(--vscode-widget-shadow);
+  z-index: 100;
+  transform: translateY(-100%);
+  visibility: hidden;
+}
+.findWidget.active {
+  transform: translateY(0);
+  visibility: visible;
+}
+.findWidget.transition {
+  transition:
+    transform 0.2s ease-out,
+    visibility 0.2s;
+}
+#findInput {
+  width: 200px;
+  padding: 3px 6px;
+  border: 1px solid rgba(128, 128, 128, 0.3);
+  background-color: var(--vscode-input-background);
+  color: var(--vscode-input-foreground);
+  font-size: 13px;
+  outline: none;
+}
+#findInput:focus {
+  border-color: var(--vscode-focusBorder);
+}
+.findWidget[data-error] #findInput {
+  border-color: var(--vscode-inputValidation-errorBorder, #f44747);
+}
+#findInput:disabled {
+  opacity: 0.5;
+}
+.findModifier {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  cursor: pointer;
+  border: 1px solid transparent;
+  border-radius: 3px;
+  font-size: 11px;
+  user-select: none;
+  opacity: 0.7;
+}
+.findModifier:hover {
+  opacity: 1;
+  background-color: rgba(128, 128, 128, 0.1);
+}
+.findModifier.active {
+  opacity: 1;
+  background-color: rgba(128, 128, 128, 0.2);
+  border-color: rgba(128, 128, 128, 0.5);
+}
+#findPosition {
+  display: inline-block;
+  min-width: 60px;
+  text-align: center;
+  font-size: 12px;
+  padding: 0 4px;
+  white-space: nowrap;
+  opacity: 0.8;
+}
+#findPrev,
+#findNext,
+#findOpenCdv,
+#findClose {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  cursor: pointer;
+  border-radius: 3px;
+}
+#findPrev:hover,
+#findNext:hover,
+#findOpenCdv:hover,
+#findClose:hover {
+  background-color: rgba(128, 128, 128, 0.15);
+}
+#findPrev svg,
+#findNext svg,
+#findOpenCdv svg,
+#findClose svg {
+  width: 14px;
+  height: 14px;
+  fill: var(--vscode-editor-foreground);
+  opacity: 0.7;
+}
+#findPrev:hover svg,
+#findNext:hover svg,
+#findOpenCdv:hover svg,
+#findClose:hover svg {
+  opacity: 1;
+}
+#findPrev.disabled,
+#findNext.disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+#findPrev.disabled:hover,
+#findNext.disabled:hover {
+  background-color: transparent;
+}
+#findOpenCdv.active {
+  background-color: rgba(128, 128, 128, 0.2);
+}
+#findOpenCdv.active svg {
+  opacity: 1;
 }
 
 /* General */

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@vscode/vsce": "^3.7.1",
     "esbuild": "^0.27.3",
     "eslint-plugin-simple-import-sort": "^12.1.1",
+    "jsdom": "^28.1.0",
     "oxfmt": "^0.33.0",
     "oxlint": "^1.48.0",
     "typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       eslint-plugin-simple-import-sort:
         specifier: ^12.1.1
         version: 12.1.1(eslint@10.0.0)
+      jsdom:
+        specifier: ^28.1.0
+        version: 28.1.0
       oxfmt:
         specifier: ^0.33.0
         version: 0.33.0
@@ -34,9 +37,22 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@22.19.11)
+        version: 4.0.18(@types/node@22.19.11)(jsdom@28.1.0)
 
 packages:
+
+  '@acemir/cssom@0.9.31':
+    resolution: {integrity: sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==}
+
+  '@asamuzakjp/css-color@5.0.1':
+    resolution: {integrity: sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@6.8.1':
+    resolution: {integrity: sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@azu/format-text@1.0.2':
     resolution: {integrity: sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg==}
@@ -95,6 +111,41 @@ packages:
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.1.1':
+    resolution: {integrity: sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.0.2':
+    resolution: {integrity: sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.28':
+    resolution: {integrity: sha512-1NRf1CUBjnr3K7hu8BLxjQrKCxEe8FP/xmPTenAxCRZWVLbmGotkFvG9mfNpjA6k7Bw1bw4BilZq9cu19RA5pg==}
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
@@ -281,6 +332,15 @@ packages:
   '@eslint/plugin-kit@0.6.0':
     resolution: {integrity: sha512-bIZEUzOI1jkhviX2cp5vNyXQc6olzb2ohewQubuYlMXZ2Q/XjBO0x0XhGPvc9fjSIiUN0vw+0hq53BJ4eQSJKQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@exodus/bytes@1.14.1':
+    resolution: {integrity: sha512-OhkBFWI6GcRMUroChZiopRiSp2iAMvEBK47NhJooDqz1RERO4QuZIZnjP63TXX8GAiLABkYmX+fuQsdJ1dd2QQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -942,6 +1002,9 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   binaryextensions@6.11.0:
     resolution: {integrity: sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw==}
     engines: {node: '>=4'}
@@ -1038,9 +1101,21 @@ packages:
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
 
+  css-tree@3.1.0:
+    resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   css-what@6.2.2:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
+
+  cssstyle@6.1.0:
+    resolution: {integrity: sha512-Ml4fP2UT2K3CUBQnVlbdV/8aFDdlY69E+YnwJM+3VUWl08S3J8c8aRuJqCkD9Py8DHZ7zNNvsfKl8psocHZEFg==}
+    engines: {node: '>=20'}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1050,6 +1125,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
@@ -1350,6 +1428,10 @@ packages:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   htmlparser2@10.1.0:
     resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
 
@@ -1416,6 +1498,9 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
@@ -1437,6 +1522,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@28.1.0:
+    resolution: {integrity: sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -1540,6 +1634,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdn-data@2.12.2:
+    resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
@@ -1685,6 +1782,9 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  parse5@8.0.0:
+    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1806,6 +1906,10 @@ packages:
     resolution: {integrity: sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==}
     engines: {node: '>=11.0.0'}
 
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   secretlint@10.2.2:
     resolution: {integrity: sha512-xVpkeHV/aoWe4vP4TansF622nBEImzCY73y/0042DuJ29iKIaqgoJ8fGxre3rVSHHbxar4FdJobmTnLp9AU0eg==}
     engines: {node: '>=20.0.0'}
@@ -1917,6 +2021,9 @@ packages:
     resolution: {integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==}
     engines: {node: '>=14.18'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   table@6.9.0:
     resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
     engines: {node: '>=10.0.0'}
@@ -1958,6 +2065,13 @@ packages:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.23:
+    resolution: {integrity: sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==}
+
+  tldts@7.0.23:
+    resolution: {integrity: sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==}
+    hasBin: true
+
   tmp@0.2.5:
     resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
     engines: {node: '>=14.14'}
@@ -1965,6 +2079,14 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  tough-cookie@6.0.0:
+    resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -2111,6 +2233,14 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
@@ -2119,6 +2249,14 @@ packages:
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
     engines: {node: '>=18'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -2141,6 +2279,10 @@ packages:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
   xml2js@0.5.0:
     resolution: {integrity: sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==}
     engines: {node: '>=4.0.0'}
@@ -2148,6 +2290,9 @@ packages:
   xmlbuilder@11.0.1:
     resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
     engines: {node: '>=4.0'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
@@ -2163,6 +2308,26 @@ packages:
     engines: {node: '>=10'}
 
 snapshots:
+
+  '@acemir/cssom@0.9.31': {}
+
+  '@asamuzakjp/css-color@5.0.1':
+    dependencies:
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.2.6
+
+  '@asamuzakjp/dom-selector@6.8.1':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.1.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.2.6
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@azu/format-text@1.0.2': {}
 
@@ -2260,6 +2425,32 @@ snapshots:
       picocolors: 1.1.1
 
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.1.0
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.0.28': {}
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
@@ -2368,6 +2559,8 @@ snapshots:
     dependencies:
       '@eslint/core': 1.1.0
       levn: 0.4.1
+
+  '@exodus/bytes@1.14.1': {}
 
   '@humanfs/core@0.19.1': {}
 
@@ -2893,6 +3086,10 @@ snapshots:
   base64-js@1.5.1:
     optional: true
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   binaryextensions@6.11.0:
     dependencies:
       editions: 6.22.0
@@ -3010,11 +3207,32 @@ snapshots:
       domutils: 3.2.2
       nth-check: 2.1.1
 
+  css-tree@3.1.0:
+    dependencies:
+      mdn-data: 2.12.2
+      source-map-js: 1.2.1
+
   css-what@6.2.2: {}
+
+  cssstyle@6.1.0:
+    dependencies:
+      '@asamuzakjp/css-color': 5.0.1
+      '@csstools/css-syntax-patches-for-csstree': 1.0.28
+      css-tree: 3.1.0
+      lru-cache: 11.2.6
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decompress-response@6.0.0:
     dependencies:
@@ -3363,6 +3581,12 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.14.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   htmlparser2@10.1.0:
     dependencies:
       domelementtype: 2.3.0
@@ -3421,6 +3645,8 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
@@ -3442,6 +3668,33 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@28.1.0:
+    dependencies:
+      '@acemir/cssom': 0.9.31
+      '@asamuzakjp/dom-selector': 6.8.1
+      '@bramus/specificity': 2.4.2
+      '@exodus/bytes': 1.14.1
+      cssstyle: 6.1.0
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.0
+      undici: 7.22.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - supports-color
 
   json-buffer@3.0.1: {}
 
@@ -3550,6 +3803,8 @@ snapshots:
       uc.micro: 2.1.0
 
   math-intrinsics@1.1.0: {}
+
+  mdn-data@2.12.2: {}
 
   mdurl@2.0.0: {}
 
@@ -3727,6 +3982,10 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parse5@8.0.0:
+    dependencies:
+      entities: 6.0.1
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -3875,6 +4134,10 @@ snapshots:
 
   sax@1.4.4: {}
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   secretlint@10.2.2:
     dependencies:
       '@secretlint/config-creator': 10.2.2
@@ -4002,6 +4265,8 @@ snapshots:
       has-flag: 4.0.0
       supports-color: 7.2.0
 
+  symbol-tree@3.2.4: {}
+
   table@6.9.0:
     dependencies:
       ajv: 8.18.0
@@ -4051,11 +4316,25 @@ snapshots:
 
   tinyrainbow@3.0.3: {}
 
+  tldts-core@7.0.23: {}
+
+  tldts@7.0.23:
+    dependencies:
+      tldts-core: 7.0.23
+
   tmp@0.2.5: {}
 
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  tough-cookie@6.0.0:
+    dependencies:
+      tldts: 7.0.23
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   tslib@2.8.1: {}
 
@@ -4124,7 +4403,7 @@ snapshots:
       '@types/node': 22.19.11
       fsevents: 2.3.3
 
-  vitest@4.0.18(@types/node@22.19.11):
+  vitest@4.0.18(@types/node@22.19.11)(jsdom@28.1.0):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@22.19.11))
@@ -4148,6 +4427,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.11
+      jsdom: 28.1.0
     transitivePeerDependencies:
       - jiti
       - less
@@ -4161,11 +4441,27 @@ snapshots:
       - tsx
       - yaml
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
   whatwg-encoding@3.1.1:
     dependencies:
       iconv-lite: 0.6.3
 
   whatwg-mimetype@4.0.0: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.14.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which@2.0.2:
     dependencies:
@@ -4185,12 +4481,16 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
 
+  xml-name-validator@5.0.0: {}
+
   xml2js@0.5.0:
     dependencies:
       sax: 1.4.4
       xmlbuilder: 11.0.1
 
   xmlbuilder@11.0.1: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@4.0.0: {}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,22 @@
 /* Git Interfaces / Types */
 
+export interface GitCommitStash {
+  selector: string;
+  baseHash: string;
+  untrackedFilesHash: string | null;
+}
+
+export interface GitStash {
+  hash: string;
+  selector: string;
+  baseHash: string;
+  untrackedFilesHash: string | null;
+  author: string;
+  email: string;
+  date: number;
+  message: string;
+}
+
 export interface GitCommitNode {
   hash: string;
   parentHashes: string[];
@@ -8,6 +25,7 @@ export interface GitCommitNode {
   date: number;
   message: string;
   refs: GitRef[];
+  stash: GitCommitStash | null;
 }
 
 export interface GitCommit {
@@ -86,6 +104,11 @@ export type TabIconColourTheme = "colour" | "grey";
 export type GitCommandStatus = string | null;
 export type GitResetMode = "soft" | "mixed" | "hard";
 export type GitFileChangeType = "A" | "M" | "D" | "R";
+
+/* Named Constants */
+
+export const UNCOMMITTED_CHANGES_HASH = "*";
+export const VALID_UNCOMMITTED_RESET_MODES: ReadonlySet<string> = new Set(["mixed", "hard"]);
 
 /* Request / Response Messages */
 
@@ -314,6 +337,19 @@ export interface RequestSaveRepoState {
   state: GitRepoState;
 }
 
+export interface RequestCompareCommits {
+  command: "compareCommits";
+  repo: string;
+  fromHash: string;
+  toHash: string;
+}
+export interface ResponseCompareCommits {
+  command: "compareCommits";
+  fileChanges: GitFileChange[] | null;
+  fromHash: string;
+  toHash: string;
+}
+
 export interface RequestViewDiff {
   command: "viewDiff";
   repo: string;
@@ -321,54 +357,156 @@ export interface RequestViewDiff {
   oldFilePath: string;
   newFilePath: string;
   type: GitFileChangeType;
+  compareWithHash?: string;
 }
 export interface ResponseViewDiff {
   command: "viewDiff";
   success: boolean;
 }
 
+export interface RequestApplyStash {
+  command: "applyStash";
+  repo: string;
+  selector: string;
+  reinstateIndex: boolean;
+}
+export interface ResponseApplyStash {
+  command: "applyStash";
+  status: GitCommandStatus;
+}
+
+export interface RequestPopStash {
+  command: "popStash";
+  repo: string;
+  selector: string;
+  reinstateIndex: boolean;
+}
+export interface ResponsePopStash {
+  command: "popStash";
+  status: GitCommandStatus;
+}
+
+export interface RequestDropStash {
+  command: "dropStash";
+  repo: string;
+  selector: string;
+}
+export interface ResponseDropStash {
+  command: "dropStash";
+  status: GitCommandStatus;
+}
+
+export interface RequestBranchFromStash {
+  command: "branchFromStash";
+  repo: string;
+  selector: string;
+  branchName: string;
+}
+export interface ResponseBranchFromStash {
+  command: "branchFromStash";
+  status: GitCommandStatus;
+}
+
+export interface RequestPushStash {
+  command: "pushStash";
+  repo: string;
+  message: string;
+  includeUntracked: boolean;
+}
+export interface ResponsePushStash {
+  command: "pushStash";
+  status: GitCommandStatus;
+}
+
+export interface RequestFetch {
+  command: "fetch";
+  repo: string;
+}
+export interface ResponseFetch {
+  command: "fetch";
+  status: GitCommandStatus;
+}
+
+export interface RequestResetUncommitted {
+  command: "resetUncommitted";
+  repo: string;
+  mode: string;
+}
+export interface ResponseResetUncommitted {
+  command: "resetUncommitted";
+  status: GitCommandStatus;
+}
+
+export interface RequestCleanUntrackedFiles {
+  command: "cleanUntrackedFiles";
+  repo: string;
+  directories: boolean;
+}
+export interface ResponseCleanUntrackedFiles {
+  command: "cleanUntrackedFiles";
+  status: GitCommandStatus;
+}
+
 export type RequestMessage =
   | RequestAddTag
+  | RequestApplyStash
+  | RequestBranchFromStash
   | RequestCheckoutBranch
   | RequestCheckoutCommit
   | RequestCherrypickCommit
+  | RequestCleanUntrackedFiles
   | RequestCommitDetails
+  | RequestCompareCommits
   | RequestCopyToClipboard
   | RequestCreateBranch
   | RequestDeleteBranch
   | RequestDeleteTag
+  | RequestDropStash
+  | RequestFetch
   | RequestFetchAvatar
   | RequestLoadBranches
   | RequestLoadCommits
   | RequestLoadRepos
   | RequestMergeBranch
   | RequestMergeCommit
+  | RequestPopStash
+  | RequestPushStash
   | RequestPushTag
   | RequestRenameBranch
   | RequestResetToCommit
+  | RequestResetUncommitted
   | RequestRevertCommit
   | RequestSaveRepoState
   | RequestViewDiff;
 
 export type ResponseMessage =
   | ResponseAddTag
+  | ResponseApplyStash
+  | ResponseBranchFromStash
   | ResponseCheckoutBranch
   | ResponseCheckoutCommit
   | ResponseCherrypickCommit
+  | ResponseCleanUntrackedFiles
   | ResponseCommitDetails
+  | ResponseCompareCommits
   | ResponseCopyToClipboard
   | ResponseCreateBranch
   | ResponseDeleteBranch
   | ResponseDeleteTag
+  | ResponseDropStash
+  | ResponseFetch
   | ResponseFetchAvatar
   | ResponseLoadBranches
   | ResponseLoadCommits
   | ResponseLoadRepos
   | ResponseMergeBranch
   | ResponseMergeCommit
+  | ResponsePopStash
+  | ResponsePushStash
   | ResponsePushTag
   | ResponseRefresh
   | ResponseRenameBranch
   | ResponseResetToCommit
+  | ResponseResetUncommitted
   | ResponseRevertCommit
   | ResponseViewDiff;

--- a/tests/src/dataSource.test.ts
+++ b/tests/src/dataSource.test.ts
@@ -1,0 +1,1660 @@
+import * as cp from "node:child_process";
+import { EventEmitter } from "node:events";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("vscode", () => ({
+  workspace: {
+    getConfiguration: vi.fn(() => ({
+      get: vi.fn()
+    }))
+  }
+}));
+
+vi.mock("../../src/config", () => ({
+  getConfig: vi.fn(() => ({
+    gitPath: () => "git",
+    dateType: () => "Author Date",
+    showUncommittedChanges: () => false
+  }))
+}));
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn()
+}));
+
+import { DataSource } from "../../src/dataSource";
+import { type GitStash, UNCOMMITTED_CHANGES_HASH } from "../../src/types";
+
+const SEP = "XX7Nal-YARtTpjCikii9nJxER19D6diSyk-AWkPb";
+const REPO = "/test/repo";
+
+type DataSourceWithPrivate = DataSource & {
+  getStashes: (repo: string) => Promise<GitStash[]>;
+};
+
+function createMockProcess(stdoutData: string, exitCode = 0, emitError = false) {
+  const stdoutEmitter = new EventEmitter();
+  const stderrEmitter = new EventEmitter();
+  const proc = new EventEmitter();
+  Object.assign(proc, { stdout: stdoutEmitter, stderr: stderrEmitter });
+
+  queueMicrotask(() => {
+    if (emitError) {
+      proc.emit("error", new Error("spawn error"));
+      return;
+    }
+    if (stdoutData) {
+      stdoutEmitter.emit("data", stdoutData);
+    }
+    proc.emit("close", exitCode);
+  });
+
+  return proc as unknown as cp.ChildProcess;
+}
+
+function makeStashLine(
+  hash: string,
+  baseHash: string,
+  indexHash: string,
+  untrackedHash: string | null,
+  selector: string,
+  author: string,
+  email: string,
+  date: number,
+  message: string
+): string {
+  const parents = untrackedHash
+    ? `${baseHash} ${indexHash} ${untrackedHash}`
+    : `${baseHash} ${indexHash}`;
+  return [hash, parents, selector, author, email, String(date), message].join(SEP);
+}
+
+function makeCommitLine(
+  hash: string,
+  parentHash: string,
+  author: string,
+  email: string,
+  date: number,
+  message: string
+): string {
+  return [hash, parentHash, author, email, String(date), message].join(SEP);
+}
+
+function setupSpawnForStash(stdoutData: string, exitCode = 0, emitError = false) {
+  const mock = cp.spawn as unknown as ReturnType<typeof vi.fn>;
+  mock.mockImplementation(() => createMockProcess(stdoutData, exitCode, emitError));
+}
+
+function setupSpawnForCommits(options: {
+  logOutput: string;
+  refOutput?: string;
+  stashOutput: string;
+}) {
+  const mock = cp.spawn as unknown as ReturnType<typeof vi.fn>;
+  mock.mockImplementation((_cmd: unknown, args: unknown) => {
+    const argArray = args as string[];
+    const subcommand = argArray[0];
+    if (subcommand === "log") {
+      return createMockProcess(options.logOutput);
+    }
+    if (subcommand === "show-ref") {
+      return createMockProcess(options.refOutput ?? "");
+    }
+    if (subcommand === "reflog") {
+      return createMockProcess(options.stashOutput);
+    }
+    return createMockProcess("");
+  });
+}
+
+describe("getStashes", () => {
+  let ds: DataSourceWithPrivate;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ds = new DataSource() as DataSourceWithPrivate;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("parses 3 stash entries from git reflog output (TC-SD-N-01)", async () => {
+    // Given: Repository has 3 stashes (mocked reflog output)
+    const output = [
+      makeStashLine(
+        "aaa111",
+        "base111",
+        "idx111",
+        "utr111",
+        "stash@{0}",
+        "Alice",
+        "alice@test.com",
+        1700000003,
+        "WIP: feature A"
+      ),
+      makeStashLine(
+        "aaa222",
+        "base222",
+        "idx222",
+        null,
+        "stash@{1}",
+        "Bob",
+        "bob@test.com",
+        1700000002,
+        "WIP: feature B"
+      ),
+      makeStashLine(
+        "aaa333",
+        "base333",
+        "idx333",
+        "utr333",
+        "stash@{2}",
+        "Alice",
+        "alice@test.com",
+        1700000001,
+        "WIP: feature C"
+      ),
+      ""
+    ].join("\n");
+    setupSpawnForStash(output);
+
+    // When: getStashes(repo) is called
+    const result = await ds.getStashes(REPO);
+
+    // Then: 3 GitStash objects are returned with all required fields
+    expect(result).toHaveLength(3);
+
+    expect(result[0]).toEqual({
+      hash: "aaa111",
+      baseHash: "base111",
+      untrackedFilesHash: "utr111",
+      selector: "stash@{0}",
+      author: "Alice",
+      email: "alice@test.com",
+      date: 1700000003,
+      message: "WIP: feature A"
+    });
+
+    expect(result[1]).toEqual({
+      hash: "aaa222",
+      baseHash: "base222",
+      untrackedFilesHash: null,
+      selector: "stash@{1}",
+      author: "Bob",
+      email: "bob@test.com",
+      date: 1700000002,
+      message: "WIP: feature B"
+    });
+
+    expect(result[2]).toEqual({
+      hash: "aaa333",
+      baseHash: "base333",
+      untrackedFilesHash: "utr333",
+      selector: "stash@{2}",
+      author: "Alice",
+      email: "alice@test.com",
+      date: 1700000001,
+      message: "WIP: feature C"
+    });
+  });
+
+  it("returns empty array when no stashes exist (TC-SD-N-02)", async () => {
+    // Given: refs/stash does not exist (git exits with code 128)
+    setupSpawnForStash("", 128);
+
+    // When: getStashes(repo) is called
+    const result = await ds.getStashes(REPO);
+
+    // Then: Empty array is returned (not an error)
+    expect(result).toEqual([]);
+  });
+
+  it("parses single stash entry (TC-SD-B-01)", async () => {
+    // Given: Repository has exactly 1 stash (minimum valid count)
+    const output = [
+      makeStashLine(
+        "sss111",
+        "base111",
+        "idx111",
+        null,
+        "stash@{0}",
+        "Alice",
+        "alice@test.com",
+        1700000001,
+        "single stash"
+      ),
+      ""
+    ].join("\n");
+    setupSpawnForStash(output);
+
+    // When: getStashes(repo) is called
+    const result = await ds.getStashes(REPO);
+
+    // Then: 1 GitStash object is returned
+    expect(result).toHaveLength(1);
+    expect(result[0].hash).toBe("sss111");
+    expect(result[0].selector).toBe("stash@{0}");
+    expect(result[0].message).toBe("single stash");
+  });
+
+  it("returns empty array when git command fails (TC-SD-A-01)", async () => {
+    // Given: spawn emits an error event (simulating process spawn failure)
+    setupSpawnForStash("", 0, true);
+
+    // When: getStashes(repo) is called
+    const result = await ds.getStashes(REPO);
+
+    // Then: Empty array is returned (graceful fallback)
+    expect(result).toEqual([]);
+  });
+
+  it("skips malformed lines with incorrect field count (TC-SD-B-02)", async () => {
+    // Given: Output contains a malformed line (3 fields) mixed with a valid line
+    const malformedLine = ["hash_only", "parents", "selector"].join(SEP);
+    const validLine = makeStashLine(
+      "aaa111",
+      "base111",
+      "idx111",
+      null,
+      "stash@{0}",
+      "Alice",
+      "alice@test.com",
+      1700000001,
+      "valid stash"
+    );
+    const output = [malformedLine, validLine, ""].join("\n");
+    setupSpawnForStash(output);
+
+    // When: getStashes(repo) is called
+    const result = await ds.getStashes(REPO);
+
+    // Then: Only the valid line is parsed; malformed line is skipped
+    expect(result).toHaveLength(1);
+    expect(result[0].hash).toBe("aaa111");
+  });
+
+  it("skips lines with empty parent hashes (TC-SD-B-03)", async () => {
+    // Given: Output contains a line with empty parent hashes (line[1] === "")
+    const emptyParentLine = [
+      "hash111",
+      "",
+      "stash@{0}",
+      "Author",
+      "a@t.com",
+      "1700000001",
+      "msg"
+    ].join(SEP);
+    const validLine = makeStashLine(
+      "aaa222",
+      "base222",
+      "idx222",
+      null,
+      "stash@{1}",
+      "Bob",
+      "bob@test.com",
+      1700000002,
+      "valid stash"
+    );
+    const output = [emptyParentLine, validLine, ""].join("\n");
+    setupSpawnForStash(output);
+
+    // When: getStashes(repo) is called
+    const result = await ds.getStashes(REPO);
+
+    // Then: Only the line with non-empty parents is parsed
+    expect(result).toHaveLength(1);
+    expect(result[0].hash).toBe("aaa222");
+  });
+});
+
+describe("stash integration in getCommits", () => {
+  let ds: DataSource;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ds = new DataSource();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("attaches stash info when stash hash matches commit hash (TC-SI-N-01)", async () => {
+    // Given: Commit array has a commit whose hash matches a stash hash
+    const commitHash = "abc123def456";
+    const baseHash = "000111222333";
+    const logOutput = [
+      makeCommitLine(commitHash, baseHash, "Author", "a@t.com", 1700000002, "stash commit"),
+      makeCommitLine(baseHash, "root000", "Author", "a@t.com", 1700000001, "base commit"),
+      ""
+    ].join("\n");
+    const stashOutput = [
+      makeStashLine(
+        commitHash,
+        baseHash,
+        "idx111",
+        null,
+        "stash@{0}",
+        "Author",
+        "a@t.com",
+        1700000002,
+        "WIP"
+      ),
+      ""
+    ].join("\n");
+    setupSpawnForCommits({ logOutput, stashOutput });
+
+    // When: getCommits is called
+    const result = await ds.getCommits(REPO, "", 10, false);
+
+    // Then: The matching commit node has stash info attached
+    const stashCommit = result.commits.find((c) => c.hash === commitHash);
+    expect(stashCommit).toBeDefined();
+    expect(stashCommit!.stash).toEqual({
+      selector: "stash@{0}",
+      baseHash: baseHash,
+      untrackedFilesHash: null
+    });
+  });
+
+  it("inserts stash node before base commit when baseHash matches (TC-SI-N-02)", async () => {
+    // Given: Stash's baseHash matches a commit, but stash hash is not in commits
+    const baseHash = "base111222333";
+    const stashHash = "sss111222333";
+    const logOutput = [
+      makeCommitLine("newer111", baseHash, "Author", "a@t.com", 1700000003, "newer"),
+      makeCommitLine(baseHash, "root000", "Author", "a@t.com", 1700000001, "base"),
+      ""
+    ].join("\n");
+    const stashOutput = [
+      makeStashLine(
+        stashHash,
+        baseHash,
+        "idx111",
+        null,
+        "stash@{0}",
+        "Author",
+        "a@t.com",
+        1700000002,
+        "WIP on main"
+      ),
+      ""
+    ].join("\n");
+    setupSpawnForCommits({ logOutput, stashOutput });
+
+    // When: getCommits is called
+    const result = await ds.getCommits(REPO, "", 10, false);
+
+    // Then: Stash node is inserted before the base commit
+    expect(result.commits).toHaveLength(3);
+    const stashIdx = result.commits.findIndex((c) => c.hash === stashHash);
+    const baseIdx = result.commits.findIndex((c) => c.hash === baseHash);
+    expect(stashIdx).toBeGreaterThanOrEqual(0);
+    expect(stashIdx).toBeLessThan(baseIdx);
+    expect(result.commits[stashIdx].stash).toEqual({
+      selector: "stash@{0}",
+      baseHash: baseHash,
+      untrackedFilesHash: null
+    });
+    expect(result.commits[stashIdx].parentHashes).toEqual([baseHash]);
+    expect(result.commits[stashIdx].message).toBe("WIP on main");
+  });
+
+  it("skips stash when neither hash nor baseHash is in commits (TC-SI-N-03)", async () => {
+    // Given: Stash hash and baseHash are both absent from the commit array
+    const logOutput = [
+      makeCommitLine("commit111", "root000", "Author", "a@t.com", 1700000001, "only commit"),
+      ""
+    ].join("\n");
+    const stashOutput = [
+      makeStashLine(
+        "sss999",
+        "notincommits",
+        "idx111",
+        null,
+        "stash@{0}",
+        "Author",
+        "a@t.com",
+        1700000002,
+        "orphan stash"
+      ),
+      ""
+    ].join("\n");
+    setupSpawnForCommits({ logOutput, stashOutput });
+
+    // When: getCommits is called
+    const result = await ds.getCommits(REPO, "", 10, false);
+
+    // Then: Commit array is unchanged (stash is skipped)
+    expect(result.commits).toHaveLength(1);
+    expect(result.commits[0].hash).toBe("commit111");
+    expect(result.commits[0].stash).toBeNull();
+  });
+
+  it("orders stashes with same baseHash by date descending (TC-SI-N-04)", async () => {
+    // Given: Two stashes with the same baseHash (newer date > older date)
+    const baseHash = "base111";
+    const newerHash = "stash_new";
+    const olderHash = "stash_old";
+    const logOutput = [
+      makeCommitLine(baseHash, "root000", "Author", "a@t.com", 1700000001, "base commit"),
+      ""
+    ].join("\n");
+    const stashOutput = [
+      makeStashLine(
+        olderHash,
+        baseHash,
+        "idx111",
+        null,
+        "stash@{1}",
+        "Author",
+        "a@t.com",
+        1700000002,
+        "older stash"
+      ),
+      makeStashLine(
+        newerHash,
+        baseHash,
+        "idx222",
+        null,
+        "stash@{0}",
+        "Author",
+        "a@t.com",
+        1700000003,
+        "newer stash"
+      ),
+      ""
+    ].join("\n");
+    setupSpawnForCommits({ logOutput, stashOutput });
+
+    // When: getCommits is called
+    const result = await ds.getCommits(REPO, "", 10, false);
+
+    // Then: Newer stash appears before older stash (date descending)
+    expect(result.commits).toHaveLength(3);
+    const newerIdx = result.commits.findIndex((c) => c.hash === newerHash);
+    const olderIdx = result.commits.findIndex((c) => c.hash === olderHash);
+    expect(newerIdx).toBeLessThan(olderIdx);
+  });
+
+  it("returns commits unchanged when zero stashes exist (TC-SI-B-02)", async () => {
+    // Given: getStashes returns empty array (no stashes)
+    const logOutput = [
+      makeCommitLine("commit111", "root000", "Author", "a@t.com", 1700000002, "first"),
+      makeCommitLine("commit222", "commit111", "Author", "a@t.com", 1700000001, "second"),
+      ""
+    ].join("\n");
+    setupSpawnForCommits({ logOutput, stashOutput: "" });
+
+    // When: getCommits is called
+    const result = await ds.getCommits(REPO, "", 10, false);
+
+    // Then: Commits are returned as-is with no stash info
+    expect(result.commits).toHaveLength(2);
+    expect(result.commits[0].stash).toBeNull();
+    expect(result.commits[1].stash).toBeNull();
+  });
+
+  it("inserts stashes at correct positions for different baseHashes (TC-SI-N-05)", async () => {
+    // Given: 3 stashes with different baseHashes matching different commits
+    const commitA = "commit_aaa";
+    const commitB = "commit_bbb";
+    const commitC = "commit_ccc";
+    const stashA = "stash_for_a";
+    const stashB = "stash_for_b";
+    const stashC = "stash_for_c";
+
+    const logOutput = [
+      makeCommitLine(commitA, commitB, "Author", "a@t.com", 1700000003, "commit A"),
+      makeCommitLine(commitB, commitC, "Author", "a@t.com", 1700000002, "commit B"),
+      makeCommitLine(commitC, "root000", "Author", "a@t.com", 1700000001, "commit C"),
+      ""
+    ].join("\n");
+    const stashOutput = [
+      makeStashLine(
+        stashA,
+        commitA,
+        "idx111",
+        null,
+        "stash@{0}",
+        "Author",
+        "a@t.com",
+        1700000006,
+        "stash for A"
+      ),
+      makeStashLine(
+        stashB,
+        commitB,
+        "idx222",
+        null,
+        "stash@{1}",
+        "Author",
+        "a@t.com",
+        1700000005,
+        "stash for B"
+      ),
+      makeStashLine(
+        stashC,
+        commitC,
+        "idx333",
+        null,
+        "stash@{2}",
+        "Author",
+        "a@t.com",
+        1700000004,
+        "stash for C"
+      ),
+      ""
+    ].join("\n");
+    setupSpawnForCommits({ logOutput, stashOutput });
+
+    // When: getCommits is called
+    const result = await ds.getCommits(REPO, "", 10, false);
+
+    // Then: Each stash is inserted before its respective base commit
+    expect(result.commits).toHaveLength(6);
+
+    const idxStashA = result.commits.findIndex((c) => c.hash === stashA);
+    const idxCommitA = result.commits.findIndex((c) => c.hash === commitA);
+    const idxStashB = result.commits.findIndex((c) => c.hash === stashB);
+    const idxCommitB = result.commits.findIndex((c) => c.hash === commitB);
+    const idxStashC = result.commits.findIndex((c) => c.hash === stashC);
+    const idxCommitC = result.commits.findIndex((c) => c.hash === commitC);
+
+    expect(idxStashA).toBeLessThan(idxCommitA);
+    expect(idxStashB).toBeLessThan(idxCommitB);
+    expect(idxStashC).toBeLessThan(idxCommitC);
+
+    expect(result.commits[idxStashA].stash).not.toBeNull();
+    expect(result.commits[idxStashB].stash).not.toBeNull();
+    expect(result.commits[idxStashC].stash).not.toBeNull();
+  });
+});
+
+describe("getCommitFile", () => {
+  let ds: DataSource;
+  const spawnMock = vi.mocked(cp.spawn);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ds = new DataSource();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns file content for a valid commit hash (TC-CF-N-01)", async () => {
+    // Given: git show succeeds with file content
+    const fileContent = "@extends('layouts.default')\n@section('title')";
+    spawnMock.mockImplementation(() => createMockProcess(fileContent));
+
+    // When: getCommitFile is called with a valid hash
+    const result = await ds.getCommitFile(REPO, "abc123def456", "src/file.ts");
+
+    // Then: returns the file content and passes correct args to git
+    expect(result).toBe(fileContent);
+    expect(spawnMock).toHaveBeenCalledWith("git", ["show", "abc123def456:src/file.ts"], {
+      cwd: REPO
+    });
+  });
+
+  it("returns file content for commit hash with ^ suffix (TC-CF-N-02)", async () => {
+    // Given: git show succeeds for parent commit
+    const fileContent = "parent version content";
+    spawnMock.mockImplementation(() => createMockProcess(fileContent));
+
+    // When: getCommitFile is called with hash^ (parent commit syntax)
+    const result = await ds.getCommitFile(REPO, "abc123def456^", "src/file.ts");
+
+    // Then: passes the ^ suffix through to git show
+    expect(result).toBe(fileContent);
+    expect(spawnMock).toHaveBeenCalledWith("git", ["show", "abc123def456^:src/file.ts"], {
+      cwd: REPO
+    });
+  });
+
+  it("returns empty string for invalid commit hash (TC-CF-B-01)", async () => {
+    // Given: an invalid commit hash containing non-hex characters
+    // When: getCommitFile is called
+    const result = await ds.getCommitFile(REPO, "not-a-valid-hash!", "src/file.ts");
+
+    // Then: returns empty without spawning git
+    expect(result).toBe("");
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("returns empty string for path with .. traversal (TC-CF-B-02)", async () => {
+    // Given: a file path containing directory traversal
+    // When: getCommitFile is called
+    const result = await ds.getCommitFile(REPO, "abc123def456", "src/../../etc/passwd");
+
+    // Then: returns empty without spawning git
+    expect(result).toBe("");
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("returns empty string when git show fails (TC-CF-A-01)", async () => {
+    // Given: git show exits with non-zero code (file doesn't exist at commit)
+    spawnMock.mockImplementation(() => createMockProcess("", 128));
+
+    // When: getCommitFile is called
+    const result = await ds.getCommitFile(REPO, "abc123def456", "nonexistent/file.ts");
+
+    // Then: returns empty string
+    expect(result).toBe("");
+  });
+
+  it("rejects hash with only ^ (no base hash) (TC-CF-B-03)", async () => {
+    // Given: commit hash is just "^" (stripping ^ leaves empty string)
+    // When: getCommitFile is called
+    const result = await ds.getCommitFile(REPO, "^", "src/file.ts");
+
+    // Then: returns empty without spawning git (empty string fails validation)
+    expect(result).toBe("");
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("returns file content for HEAD ref (TC-CF-N-03)", async () => {
+    // Given: git show HEAD:path succeeds with file content
+    const fileContent = "content at HEAD";
+    spawnMock.mockImplementation(() => createMockProcess(fileContent));
+
+    // When: getCommitFile is called with "HEAD"
+    const result = await ds.getCommitFile(REPO, "HEAD", "src/file.ts");
+
+    // Then: returns the file content and passes correct args to git
+    expect(result).toBe(fileContent);
+    expect(spawnMock).toHaveBeenCalledWith("git", ["show", "HEAD:src/file.ts"], {
+      cwd: REPO
+    });
+  });
+
+  it("returns file content for HEAD^ ref (TC-CF-N-04)", async () => {
+    // Given: git show HEAD^:path succeeds with file content
+    const fileContent = "content at HEAD parent";
+    spawnMock.mockImplementation(() => createMockProcess(fileContent));
+
+    // When: getCommitFile is called with "HEAD^"
+    const result = await ds.getCommitFile(REPO, "HEAD^", "src/file.ts");
+
+    // Then: returns the file content with HEAD^ passed through to git
+    expect(result).toBe(fileContent);
+    expect(spawnMock).toHaveBeenCalledWith("git", ["show", "HEAD^:src/file.ts"], {
+      cwd: REPO
+    });
+  });
+});
+
+function createCommandMockProcess(
+  options: {
+    stdout?: string;
+    stderr?: string;
+    exitCode?: number;
+    emitError?: boolean;
+  } = {}
+) {
+  const { stdout = "", stderr = "", exitCode = 0, emitError = false } = options;
+  const stdoutEmitter = new EventEmitter();
+  const stderrEmitter = new EventEmitter();
+  const proc = new EventEmitter();
+  Object.assign(proc, { stdout: stdoutEmitter, stderr: stderrEmitter });
+
+  queueMicrotask(() => {
+    if (emitError) {
+      proc.emit("error", new Error("spawn error"));
+      return;
+    }
+    if (stdout) stdoutEmitter.emit("data", stdout);
+    if (stderr) stderrEmitter.emit("data", stderr);
+    proc.emit("close", exitCode);
+  });
+
+  return proc as unknown as cp.ChildProcess;
+}
+
+describe("stash commands", () => {
+  let ds: DataSource;
+  const spawnMock = vi.mocked(cp.spawn);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ds = new DataSource();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("applyStash passes correct args without --index (TC-BS-N-01)", async () => {
+    // Given: DataSource instance
+    spawnMock.mockImplementation(() => createCommandMockProcess());
+
+    // When: applyStash(repo, "stash@{0}", false)
+    const result = await ds.applyStash(REPO, "stash@{0}", false);
+
+    // Then: spawn is called with ["stash", "apply", "stash@{0}"]
+    expect(result).toBeNull();
+    expect(spawnMock).toHaveBeenCalledWith("git", ["stash", "apply", "stash@{0}"], { cwd: REPO });
+  });
+
+  it("applyStash passes --index flag when reinstateIndex is true (TC-BS-N-02)", async () => {
+    // Given: DataSource instance
+    spawnMock.mockImplementation(() => createCommandMockProcess());
+
+    // When: applyStash(repo, "stash@{0}", true)
+    const result = await ds.applyStash(REPO, "stash@{0}", true);
+
+    // Then: spawn is called with --index flag
+    expect(result).toBeNull();
+    expect(spawnMock).toHaveBeenCalledWith("git", ["stash", "apply", "--index", "stash@{0}"], {
+      cwd: REPO
+    });
+  });
+
+  it("popStash passes correct args without --index (TC-BS-N-03)", async () => {
+    // Given: DataSource instance
+    spawnMock.mockImplementation(() => createCommandMockProcess());
+
+    // When: popStash(repo, "stash@{1}", false)
+    const result = await ds.popStash(REPO, "stash@{1}", false);
+
+    // Then: spawn is called with ["stash", "pop", "stash@{1}"]
+    expect(result).toBeNull();
+    expect(spawnMock).toHaveBeenCalledWith("git", ["stash", "pop", "stash@{1}"], { cwd: REPO });
+  });
+
+  it("popStash passes --index flag when reinstateIndex is true (TC-BS-N-04)", async () => {
+    // Given: DataSource instance
+    spawnMock.mockImplementation(() => createCommandMockProcess());
+
+    // When: popStash(repo, "stash@{1}", true)
+    const result = await ds.popStash(REPO, "stash@{1}", true);
+
+    // Then: spawn is called with --index flag
+    expect(result).toBeNull();
+    expect(spawnMock).toHaveBeenCalledWith("git", ["stash", "pop", "--index", "stash@{1}"], {
+      cwd: REPO
+    });
+  });
+
+  it("dropStash passes correct args (TC-BS-N-05)", async () => {
+    // Given: DataSource instance
+    spawnMock.mockImplementation(() => createCommandMockProcess());
+
+    // When: dropStash(repo, "stash@{2}")
+    const result = await ds.dropStash(REPO, "stash@{2}");
+
+    // Then: spawn is called with ["stash", "drop", "stash@{2}"]
+    expect(result).toBeNull();
+    expect(spawnMock).toHaveBeenCalledWith("git", ["stash", "drop", "stash@{2}"], { cwd: REPO });
+  });
+
+  it("branchFromStash passes correct args (TC-BS-N-06)", async () => {
+    // Given: DataSource instance
+    spawnMock.mockImplementation(() => createCommandMockProcess());
+
+    // When: branchFromStash(repo, "my-branch", "stash@{0}")
+    const result = await ds.branchFromStash(REPO, "my-branch", "stash@{0}");
+
+    // Then: spawn is called with ["stash", "branch", "my-branch", "stash@{0}"]
+    expect(result).toBeNull();
+    expect(spawnMock).toHaveBeenCalledWith("git", ["stash", "branch", "my-branch", "stash@{0}"], {
+      cwd: REPO
+    });
+  });
+
+  it("returns error message when applyStash encounters a conflict (TC-BS-A-01)", async () => {
+    // Given: spawn outputs conflict message on stderr with non-zero exit
+    spawnMock.mockImplementation(() =>
+      createCommandMockProcess({
+        stderr: "CONFLICT (content): Merge conflict in file.txt\n",
+        exitCode: 1
+      })
+    );
+
+    // When: applyStash is executed
+    const result = await ds.applyStash(REPO, "stash@{0}", false);
+
+    // Then: Error message string is returned (not null)
+    expect(result).not.toBeNull();
+    expect(result).toContain("CONFLICT");
+  });
+
+  it("returns error message when dropStash receives invalid selector (TC-BS-A-02)", async () => {
+    // Given: spawn outputs error on stderr with non-zero exit
+    spawnMock.mockImplementation(() =>
+      createCommandMockProcess({
+        stderr: "error: stash@{99} is not a valid reference\n",
+        exitCode: 1
+      })
+    );
+
+    // When: dropStash is executed
+    const result = await ds.dropStash(REPO, "stash@{99}");
+
+    // Then: Error message string is returned
+    expect(result).not.toBeNull();
+    expect(result).toContain("error");
+  });
+});
+
+describe("uncommitted commands", () => {
+  let ds: DataSource;
+  const spawnMock = vi.mocked(cp.spawn);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ds = new DataSource();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // --- pushStash ---
+
+  it("pushStash passes full options: message + includeUntracked (TC-BU-N-01)", async () => {
+    // Given: DataSource instance
+    spawnMock.mockImplementation(() => createCommandMockProcess());
+
+    // When: pushStash(repo, "WIP message", true)
+    const result = await ds.pushStash(REPO, "WIP message", true);
+
+    // Then: spawn is called with ["stash", "push", "--message", "WIP message", "--include-untracked"]
+    expect(result).toBeNull();
+    expect(spawnMock).toHaveBeenCalledWith(
+      "git",
+      ["stash", "push", "--message", "WIP message", "--include-untracked"],
+      { cwd: REPO }
+    );
+  });
+
+  it("pushStash passes message only when includeUntracked is false (TC-BU-N-02)", async () => {
+    // Given: DataSource instance
+    spawnMock.mockImplementation(() => createCommandMockProcess());
+
+    // When: pushStash(repo, "WIP message", false)
+    const result = await ds.pushStash(REPO, "WIP message", false);
+
+    // Then: spawn is called with ["stash", "push", "--message", "WIP message"]
+    expect(result).toBeNull();
+    expect(spawnMock).toHaveBeenCalledWith("git", ["stash", "push", "--message", "WIP message"], {
+      cwd: REPO
+    });
+  });
+
+  it("pushStash passes --include-untracked only when message is empty (TC-BU-N-03)", async () => {
+    // Given: DataSource instance
+    spawnMock.mockImplementation(() => createCommandMockProcess());
+
+    // When: pushStash(repo, "", true)
+    const result = await ds.pushStash(REPO, "", true);
+
+    // Then: spawn is called with ["stash", "push", "--include-untracked"] (no --message flag)
+    expect(result).toBeNull();
+    expect(spawnMock).toHaveBeenCalledWith("git", ["stash", "push", "--include-untracked"], {
+      cwd: REPO
+    });
+  });
+
+  it("pushStash passes minimal args when message is empty and includeUntracked is false (TC-BU-B-01)", async () => {
+    // Given: DataSource instance
+    spawnMock.mockImplementation(() => createCommandMockProcess());
+
+    // When: pushStash(repo, "", false)
+    const result = await ds.pushStash(REPO, "", false);
+
+    // Then: spawn is called with ["stash", "push"] only
+    expect(result).toBeNull();
+    expect(spawnMock).toHaveBeenCalledWith("git", ["stash", "push"], { cwd: REPO });
+  });
+
+  // --- resetUncommitted ---
+
+  it("resetUncommitted passes correct args for mixed mode (TC-BU-N-04)", async () => {
+    // Given: DataSource instance
+    spawnMock.mockImplementation(() => createCommandMockProcess());
+
+    // When: resetUncommitted(repo, "mixed")
+    const result = await ds.resetUncommitted(REPO, "mixed");
+
+    // Then: spawn is called with ["reset", "--mixed", "HEAD"]
+    expect(result).toBeNull();
+    expect(spawnMock).toHaveBeenCalledWith("git", ["reset", "--mixed", "HEAD"], { cwd: REPO });
+  });
+
+  it("resetUncommitted passes correct args for hard mode (TC-BU-N-05)", async () => {
+    // Given: DataSource instance
+    spawnMock.mockImplementation(() => createCommandMockProcess());
+
+    // When: resetUncommitted(repo, "hard")
+    const result = await ds.resetUncommitted(REPO, "hard");
+
+    // Then: spawn is called with ["reset", "--hard", "HEAD"]
+    expect(result).toBeNull();
+    expect(spawnMock).toHaveBeenCalledWith("git", ["reset", "--hard", "HEAD"], { cwd: REPO });
+  });
+
+  it("resetUncommitted rejects soft mode (TC-BU-A-01)", async () => {
+    // Given: DataSource instance
+    spawnMock.mockImplementation(() => createCommandMockProcess());
+
+    // When: resetUncommitted(repo, "soft")
+    const result = await ds.resetUncommitted(REPO, "soft");
+
+    // Then: Error is returned and git command is NOT executed
+    expect(result).toBe("Invalid reset mode.");
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("resetUncommitted rejects arbitrary invalid mode (TC-BU-A-02)", async () => {
+    // Given: DataSource instance
+    spawnMock.mockImplementation(() => createCommandMockProcess());
+
+    // When: resetUncommitted(repo, "invalid")
+    const result = await ds.resetUncommitted(REPO, "invalid");
+
+    // Then: Error is returned and git command is NOT executed
+    expect(result).toBe("Invalid reset mode.");
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("resetUncommitted rejects empty string mode (TC-BU-A-03)", async () => {
+    // Given: DataSource instance
+    spawnMock.mockImplementation(() => createCommandMockProcess());
+
+    // When: resetUncommitted(repo, "")
+    const result = await ds.resetUncommitted(REPO, "");
+
+    // Then: Error is returned and git command is NOT executed
+    expect(result).toBe("Invalid reset mode.");
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  // --- cleanUntrackedFiles ---
+
+  it("cleanUntrackedFiles passes -f without -d when directories is false (TC-BU-N-06)", async () => {
+    // Given: DataSource instance
+    spawnMock.mockImplementation(() => createCommandMockProcess());
+
+    // When: cleanUntrackedFiles(repo, false)
+    const result = await ds.cleanUntrackedFiles(REPO, false);
+
+    // Then: spawn is called with ["clean", "-f"]
+    expect(result).toBeNull();
+    expect(spawnMock).toHaveBeenCalledWith("git", ["clean", "-f"], { cwd: REPO });
+  });
+
+  it("cleanUntrackedFiles passes -f -d when directories is true (TC-BU-N-07)", async () => {
+    // Given: DataSource instance
+    spawnMock.mockImplementation(() => createCommandMockProcess());
+
+    // When: cleanUntrackedFiles(repo, true)
+    const result = await ds.cleanUntrackedFiles(REPO, true);
+
+    // Then: spawn is called with ["clean", "-f", "-d"]
+    expect(result).toBeNull();
+    expect(spawnMock).toHaveBeenCalledWith("git", ["clean", "-f", "-d"], { cwd: REPO });
+  });
+
+  // --- Error handling ---
+
+  it("pushStash returns error message when git command fails (TC-BU-A-04)", async () => {
+    // Given: spawn outputs error on stderr with non-zero exit
+    spawnMock.mockImplementation(() =>
+      createCommandMockProcess({
+        stderr: "error: no local changes to save\n",
+        exitCode: 1
+      })
+    );
+
+    // When: pushStash is executed
+    const result = await ds.pushStash(REPO, "", false);
+
+    // Then: Error message string is returned (not null)
+    expect(result).not.toBeNull();
+    expect(result).toContain("no local changes to save");
+  });
+
+  it("cleanUntrackedFiles returns error message when git command fails (TC-BU-A-05)", async () => {
+    // Given: spawn outputs error on stderr with non-zero exit
+    spawnMock.mockImplementation(() =>
+      createCommandMockProcess({
+        stderr: "fatal: clean.requireForce defaults to true\n",
+        exitCode: 128
+      })
+    );
+
+    // When: cleanUntrackedFiles is executed
+    const result = await ds.cleanUntrackedFiles(REPO, false);
+
+    // Then: Error message string is returned (not null)
+    expect(result).not.toBeNull();
+    expect(result).toContain("clean.requireForce");
+  });
+});
+
+describe("fetch command", () => {
+  let ds: DataSource;
+  const spawnMock = vi.mocked(cp.spawn);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ds = new DataSource();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetch passes correct args: ['fetch', '--all'] (TC-FT-N-01)", async () => {
+    // Given: DataSource instance
+    spawnMock.mockImplementation(() => createCommandMockProcess());
+
+    // When: fetch(repo) is called
+    const result = await ds.fetch(REPO);
+
+    // Then: spawn is called with ["fetch", "--all"]
+    expect(result).toBeNull();
+    expect(spawnMock).toHaveBeenCalledWith("git", ["fetch", "--all"], { cwd: REPO });
+  });
+
+  it("fetch returns null on success (TC-FT-N-02)", async () => {
+    // Given: spawn completes successfully (exit code 0)
+    spawnMock.mockImplementation(() => createCommandMockProcess({ stdout: "From origin\n" }));
+
+    // When: fetch(repo) is called
+    const result = await ds.fetch(REPO);
+
+    // Then: null is returned (GitCommandStatus success)
+    expect(result).toBeNull();
+  });
+
+  it("fetch returns error message when network error occurs (TC-FT-A-01)", async () => {
+    // Given: spawn outputs error on stderr with non-zero exit
+    spawnMock.mockImplementation(() =>
+      createCommandMockProcess({
+        stderr: "fatal: unable to access 'https://github.com/repo.git/': Could not resolve host\n",
+        exitCode: 128
+      })
+    );
+
+    // When: fetch is executed
+    const result = await ds.fetch(REPO);
+
+    // Then: Error message string is returned (not null)
+    expect(result).not.toBeNull();
+    expect(result).toContain("Could not resolve host");
+  });
+
+  it("fetch returns error message when spawn emits error event (TC-FT-A-01b)", async () => {
+    // Given: spawn emits an error event (process spawn failure)
+    spawnMock.mockImplementation(() => createCommandMockProcess({ emitError: true }));
+
+    // When: fetch is executed
+    const result = await ds.fetch(REPO);
+
+    // Then: Error message string is returned (not null)
+    expect(result).not.toBeNull();
+  });
+});
+
+describe("getCommitComparison", () => {
+  let ds: DataSource;
+  const spawnMock = vi.mocked(cp.spawn);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ds = new DataSource();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function setupSpawnForComparison(nameStatusOutput: string, numStatOutput: string) {
+    spawnMock.mockImplementation((_cmd: unknown, args: unknown) => {
+      const argArray = args as string[];
+      if (argArray.includes("--name-status")) {
+        return createMockProcess(nameStatusOutput);
+      }
+      if (argArray.includes("--numstat")) {
+        return createMockProcess(numStatOutput);
+      }
+      return createMockProcess("");
+    });
+  }
+
+  it("returns file changes for two valid commit hashes (TC-DC-N-01)", async () => {
+    // Given: Two valid commit hashes with modified and added files in diff output
+    const nameStatus = "M\tsrc/modified.ts\nA\tsrc/added.ts\n";
+    const numStat = "10\t5\tsrc/modified.ts\n20\t0\tsrc/added.ts\n";
+    setupSpawnForComparison(nameStatus, numStat);
+
+    // When: getCommitComparison is called with two valid hashes
+    const result = await ds.getCommitComparison(REPO, "abc123def456", "def456abc123");
+
+    // Then: Returns GitFileChange[] with correct oldFilePath, newFilePath, type, additions, deletions
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(2);
+    expect(result![0]).toEqual({
+      oldFilePath: "src/modified.ts",
+      newFilePath: "src/modified.ts",
+      type: "M",
+      additions: 10,
+      deletions: 5
+    });
+    expect(result![1]).toEqual({
+      oldFilePath: "src/added.ts",
+      newFilePath: "src/added.ts",
+      type: "A",
+      additions: 20,
+      deletions: 0
+    });
+    // Verify nameStatus and numStat are executed in parallel (2 spawn calls)
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns different oldFilePath and newFilePath for renamed files (TC-DC-N-02)", async () => {
+    // Given: Diff contains a renamed file (R100 status with old and new paths)
+    const nameStatus = "R100\tsrc/old-name.ts\tsrc/new-name.ts\n";
+    const numStat = "8\t3\tsrc/{old-name.ts => new-name.ts}\n";
+    setupSpawnForComparison(nameStatus, numStat);
+
+    // When: getCommitComparison is called
+    const result = await ds.getCommitComparison(REPO, "abc123def456", "def456abc123");
+
+    // Then: oldFilePath and newFilePath differ, type is "R", additions/deletions are parsed
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+    expect(result![0].oldFilePath).toBe("src/old-name.ts");
+    expect(result![0].newFilePath).toBe("src/new-name.ts");
+    expect(result![0].type).toBe("R");
+    expect(result![0].additions).toBe(8);
+    expect(result![0].deletions).toBe(3);
+  });
+
+  it("correctly classifies all change types A/M/D/R (TC-DC-N-03)", async () => {
+    // Given: Diff contains all 4 change types (Added, Modified, Deleted, Renamed)
+    const nameStatus = [
+      "A\tsrc/added.ts",
+      "M\tsrc/modified.ts",
+      "D\tsrc/deleted.ts",
+      "R100\tsrc/old.ts\tsrc/renamed.ts",
+      ""
+    ].join("\n");
+    const numStat = [
+      "10\t0\tsrc/added.ts",
+      "5\t3\tsrc/modified.ts",
+      "0\t15\tsrc/deleted.ts",
+      "2\t1\tsrc/{old.ts => renamed.ts}",
+      ""
+    ].join("\n");
+    setupSpawnForComparison(nameStatus, numStat);
+
+    // When: getCommitComparison is called
+    const result = await ds.getCommitComparison(REPO, "abc123def456", "def456abc123");
+
+    // Then: Each change type is correctly identified
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(4);
+    expect(result![0].type).toBe("A");
+    expect(result![1].type).toBe("M");
+    expect(result![2].type).toBe("D");
+    expect(result![3].type).toBe("R");
+  });
+
+  it("parses numStat additions and deletions as numbers (TC-DC-N-04)", async () => {
+    // Given: numStat output with specific addition/deletion counts
+    const nameStatus = "M\tsrc/file.ts\n";
+    const numStat = "42\t17\tsrc/file.ts\n";
+    setupSpawnForComparison(nameStatus, numStat);
+
+    // When: getCommitComparison is called
+    const result = await ds.getCommitComparison(REPO, "abc123def456", "def456abc123");
+
+    // Then: additions and deletions are parsed as numbers (not strings)
+    expect(result).not.toBeNull();
+    expect(result![0].additions).toBe(42);
+    expect(result![0].deletions).toBe(17);
+  });
+
+  it("omits toHash from git args when toHash is empty string (TC-DC-B-01)", async () => {
+    // Given: toHash is empty string (working tree comparison)
+    const nameStatus = "M\tsrc/file.ts\n";
+    const numStat = "5\t2\tsrc/file.ts\n";
+    setupSpawnForComparison(nameStatus, numStat);
+
+    // When: getCommitComparison is called with empty toHash
+    const result = await ds.getCommitComparison(REPO, "abc123def456", "");
+
+    // Then: git diff args end with fromHash only (toHash not appended)
+    expect(result).not.toBeNull();
+    const nameStatusCall = spawnMock.mock.calls.find((call) =>
+      (call[1] as string[]).includes("--name-status")
+    );
+    expect(nameStatusCall).toBeDefined();
+    const args = nameStatusCall![1] as string[];
+    expect(args).toEqual([
+      "-c",
+      "core.quotePath=false",
+      "diff",
+      "--name-status",
+      "--find-renames",
+      "--diff-filter=AMDR",
+      "abc123def456"
+    ]);
+  });
+
+  it("uses toHash as diff base when fromHash is UNCOMMITTED_CHANGES_HASH (TC-DC-B-02)", async () => {
+    // Given: fromHash is UNCOMMITTED_CHANGES_HASH ("*")
+    const nameStatus = "M\tsrc/file.ts\n";
+    const numStat = "3\t1\tsrc/file.ts\n";
+    setupSpawnForComparison(nameStatus, numStat);
+
+    // When: getCommitComparison is called with UNCOMMITTED_CHANGES_HASH as fromHash
+    const result = await ds.getCommitComparison(REPO, UNCOMMITTED_CHANGES_HASH, "abc123def456");
+
+    // Then: toHash is used as the single diff base (comparing toHash against working tree)
+    expect(result).not.toBeNull();
+    const nameStatusCall = spawnMock.mock.calls.find((call) =>
+      (call[1] as string[]).includes("--name-status")
+    );
+    const args = nameStatusCall![1] as string[];
+    expect(args).toContain("abc123def456");
+    expect(args).not.toContain(UNCOMMITTED_CHANGES_HASH);
+    // toHash should be the only commit arg (no second commit = working tree comparison)
+    const diffIndex = args.indexOf("diff");
+    const commitArgs = args.slice(diffIndex + 1).filter((a) => !a.startsWith("-"));
+    expect(commitArgs).toEqual(["abc123def456"]);
+  });
+
+  it("returns empty array when no changes exist (TC-DC-B-03)", async () => {
+    // Given: git diff returns empty output (identical commits or no changes)
+    setupSpawnForComparison("", "");
+
+    // When: getCommitComparison is called
+    const result = await ds.getCommitComparison(REPO, "abc123def456", "def456abc123");
+
+    // Then: Returns empty array (not null)
+    expect(result).toEqual([]);
+    expect(result).not.toBeNull();
+  });
+
+  it("returns null when git spawn throws an exception (TC-DC-A-01)", async () => {
+    // Given: cp.spawn throws synchronously (e.g., binary not found)
+    spawnMock.mockImplementation(() => {
+      throw new Error("spawn ENOENT");
+    });
+
+    // When: getCommitComparison is called
+    const result = await ds.getCommitComparison(REPO, "abc123def456", "def456abc123");
+
+    // Then: Returns null (caught by try-catch block)
+    expect(result).toBeNull();
+  });
+
+  it("returns file changes with null additions/deletions when numStat has no matching entry (TC-DC-A-02)", async () => {
+    // Given: nameStatus has 2 entries but numStat output references a different file
+    const nameStatus = "M\tsrc/file1.ts\nA\tsrc/file2.ts\n";
+    const numStat = "10\t5\tsrc/unrelated.ts\n";
+    setupSpawnForComparison(nameStatus, numStat);
+
+    // When: getCommitComparison is called
+    const result = await ds.getCommitComparison(REPO, "abc123def456", "def456abc123");
+
+    // Then: File changes are returned but additions/deletions remain null (no numStat match)
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(2);
+    expect(result![0].additions).toBeNull();
+    expect(result![0].deletions).toBeNull();
+    expect(result![1].additions).toBeNull();
+    expect(result![1].deletions).toBeNull();
+  });
+
+  it("returns null for invalid fromHash (non-hex characters)", async () => {
+    // Given: fromHash contains invalid characters (not a valid commit hash)
+    // When: getCommitComparison is called with invalid fromHash
+    const result = await ds.getCommitComparison(REPO, "not-valid!", "abc123def456");
+
+    // Then: Returns null without spawning git
+    expect(result).toBeNull();
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("returns null for invalid toHash (non-hex characters)", async () => {
+    // Given: toHash contains invalid characters (not a valid commit hash)
+    // When: getCommitComparison is called with invalid toHash
+    const result = await ds.getCommitComparison(REPO, "abc123def456", "not-valid!");
+
+    // Then: Returns null without spawning git
+    expect(result).toBeNull();
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  /* ---------------------------------------------------------------- */
+  /* Untracked files integration (bugfix 27d2b61)                     */
+  /* ---------------------------------------------------------------- */
+
+  function setupSpawnForComparisonWithUntracked(
+    nameStatusOutput: string,
+    numStatOutput: string,
+    untrackedOutput: string
+  ) {
+    spawnMock.mockImplementation((_cmd: unknown, args: unknown) => {
+      const argArray = args as string[];
+      if (argArray.includes("--name-status")) {
+        return createMockProcess(nameStatusOutput);
+      }
+      if (argArray.includes("--numstat")) {
+        return createMockProcess(numStatOutput);
+      }
+      if (argArray.includes("ls-files")) {
+        return createMockProcess(untrackedOutput);
+      }
+      return createMockProcess("");
+    });
+  }
+
+  it("includes untracked files when fromHash is UNCOMMITTED_CHANGES_HASH (TC-DC-N-05)", async () => {
+    // Given: fromHash is UNCOMMITTED_CHANGES_HASH, diff has 1 modified file, ls-files has 1 untracked file
+    const nameStatus = "M\tsrc/existing.ts\n";
+    const numStat = "5\t2\tsrc/existing.ts\n";
+    const untracked = "src/newfile.ts\n";
+    setupSpawnForComparisonWithUntracked(nameStatus, numStat, untracked);
+
+    // When: getCommitComparison is called with UNCOMMITTED_CHANGES_HASH
+    const result = await ds.getCommitComparison(REPO, UNCOMMITTED_CHANGES_HASH, "abc123def456");
+
+    // Then: result includes both the diff file and the untracked file
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(2);
+    expect(result![0]).toEqual({
+      oldFilePath: "src/existing.ts",
+      newFilePath: "src/existing.ts",
+      type: "M",
+      additions: 5,
+      deletions: 2
+    });
+    expect(result![1]).toEqual({
+      oldFilePath: "src/newfile.ts",
+      newFilePath: "src/newfile.ts",
+      type: "A",
+      additions: null,
+      deletions: null
+    });
+  });
+
+  it("includes untracked files when toHash is empty string (TC-DC-N-06)", async () => {
+    // Given: toHash is empty string (working tree comparison), ls-files has untracked files
+    const nameStatus = "M\tsrc/file.ts\n";
+    const numStat = "3\t1\tsrc/file.ts\n";
+    const untracked = "src/untracked.ts\n";
+    setupSpawnForComparisonWithUntracked(nameStatus, numStat, untracked);
+
+    // When: getCommitComparison is called with empty toHash
+    const result = await ds.getCommitComparison(REPO, "abc123def456", "");
+
+    // Then: result includes both the diff file and the untracked file
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(2);
+    expect(result![1]).toEqual({
+      oldFilePath: "src/untracked.ts",
+      newFilePath: "src/untracked.ts",
+      type: "A",
+      additions: null,
+      deletions: null
+    });
+  });
+
+  it("does not run ls-files for two-commit comparison (TC-DC-B-04)", async () => {
+    // Given: both fromHash and toHash are valid commit hashes
+    const nameStatus = "M\tsrc/file.ts\n";
+    const numStat = "3\t1\tsrc/file.ts\n";
+    setupSpawnForComparison(nameStatus, numStat);
+
+    // When: getCommitComparison is called with two valid hashes
+    const result = await ds.getCommitComparison(REPO, "abc123def456", "def456abc123");
+
+    // Then: only 2 spawn calls (nameStatus + numStat), no ls-files
+    expect(result).not.toBeNull();
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+    const lsFilesCall = spawnMock.mock.calls.find((call) =>
+      (call[1] as string[]).includes("ls-files")
+    );
+    expect(lsFilesCall).toBeUndefined();
+  });
+
+  it("deduplicates untracked files already present in diff output (TC-DC-B-05)", async () => {
+    // Given: working tree comparison, untracked file has same name as a file in diff output
+    const nameStatus = "M\tsrc/file.ts\n";
+    const numStat = "3\t1\tsrc/file.ts\n";
+    const untracked = "src/file.ts\n";
+    setupSpawnForComparisonWithUntracked(nameStatus, numStat, untracked);
+
+    // When: getCommitComparison is called with UNCOMMITTED_CHANGES_HASH
+    const result = await ds.getCommitComparison(REPO, UNCOMMITTED_CHANGES_HASH, "abc123def456");
+
+    // Then: file appears only once (fileLookup skips duplicate)
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+    expect(result![0].type).toBe("M");
+  });
+
+  it("returns diff-only results when ls-files output is empty (TC-DC-B-06)", async () => {
+    // Given: working tree comparison, ls-files returns empty output
+    const nameStatus = "M\tsrc/file.ts\n";
+    const numStat = "3\t1\tsrc/file.ts\n";
+    const untracked = "";
+    setupSpawnForComparisonWithUntracked(nameStatus, numStat, untracked);
+
+    // When: getCommitComparison is called with UNCOMMITTED_CHANGES_HASH
+    const result = await ds.getCommitComparison(REPO, UNCOMMITTED_CHANGES_HASH, "abc123def456");
+
+    // Then: only diff result is returned, no extra entries
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+    expect(result![0].type).toBe("M");
+  });
+
+  it("skips empty lines in ls-files output (TC-DC-B-07)", async () => {
+    // Given: working tree comparison, ls-files output has empty lines mixed in
+    const nameStatus = "M\tsrc/file.ts\n";
+    const numStat = "3\t1\tsrc/file.ts\n";
+    const untracked = "src/new1.ts\n\nsrc/new2.ts\n";
+    setupSpawnForComparisonWithUntracked(nameStatus, numStat, untracked);
+
+    // When: getCommitComparison is called with UNCOMMITTED_CHANGES_HASH
+    const result = await ds.getCommitComparison(REPO, UNCOMMITTED_CHANGES_HASH, "abc123def456");
+
+    // Then: empty lines are skipped, only valid file paths are added
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(3);
+    expect(result![1].newFilePath).toBe("src/new1.ts");
+    expect(result![2].newFilePath).toBe("src/new2.ts");
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* Tests: getUncommittedDetails (bugfix 27d2b61)                      */
+/* ------------------------------------------------------------------ */
+
+describe("getUncommittedDetails", () => {
+  let ds: DataSource;
+  const spawnMock = vi.mocked(cp.spawn);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ds = new DataSource();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function setupSpawnForUncommitted(
+    nameStatusOutput: string,
+    numStatOutput: string,
+    untrackedOutput: string
+  ) {
+    spawnMock.mockImplementation((_cmd: unknown, args: unknown) => {
+      const argArray = args as string[];
+      if (argArray.includes("--name-status")) {
+        return createMockProcess(nameStatusOutput);
+      }
+      if (argArray.includes("--numstat")) {
+        return createMockProcess(numStatOutput);
+      }
+      if (argArray.includes("ls-files")) {
+        return createMockProcess(untrackedOutput);
+      }
+      return createMockProcess("");
+    });
+  }
+
+  it("returns diff changes plus untracked files (TC-UD-N-01)", async () => {
+    // Given: diff has 1 modified file, ls-files has 1 untracked file
+    const nameStatus = "M\tsrc/modified.ts\n";
+    const numStat = "10\t3\tsrc/modified.ts\n";
+    const untracked = "src/newfile.ts\n";
+    setupSpawnForUncommitted(nameStatus, numStat, untracked);
+
+    // When: getUncommittedDetails is called
+    const result = await ds.getUncommittedDetails(REPO);
+
+    // Then: fileChanges contains both the diff file and untracked file
+    expect(result).not.toBeNull();
+    expect(result!.hash).toBe(UNCOMMITTED_CHANGES_HASH);
+    expect(result!.fileChanges).toHaveLength(2);
+    expect(result!.fileChanges[0]).toEqual({
+      oldFilePath: "src/modified.ts",
+      newFilePath: "src/modified.ts",
+      type: "M",
+      additions: 10,
+      deletions: 3
+    });
+    expect(result!.fileChanges[1]).toEqual({
+      oldFilePath: "src/newfile.ts",
+      newFilePath: "src/newfile.ts",
+      type: "A",
+      additions: null,
+      deletions: null
+    });
+  });
+
+  it("returns diff changes only when no untracked files exist (TC-UD-N-02)", async () => {
+    // Given: diff has changes but ls-files returns empty output
+    const nameStatus = "M\tsrc/file.ts\n";
+    const numStat = "5\t2\tsrc/file.ts\n";
+    const untracked = "";
+    setupSpawnForUncommitted(nameStatus, numStat, untracked);
+
+    // When: getUncommittedDetails is called
+    const result = await ds.getUncommittedDetails(REPO);
+
+    // Then: fileChanges contains only the diff file
+    expect(result).not.toBeNull();
+    expect(result!.fileChanges).toHaveLength(1);
+    expect(result!.fileChanges[0].type).toBe("M");
+  });
+
+  it("returns only untracked files when diff output is empty (TC-UD-B-01)", async () => {
+    // Given: no diff output, ls-files has 2 untracked files
+    const nameStatus = "";
+    const numStat = "";
+    const untracked = "src/new1.ts\nsrc/new2.ts\n";
+    setupSpawnForUncommitted(nameStatus, numStat, untracked);
+
+    // When: getUncommittedDetails is called
+    const result = await ds.getUncommittedDetails(REPO);
+
+    // Then: fileChanges contains only untracked files with type "A" and null additions/deletions
+    expect(result).not.toBeNull();
+    expect(result!.fileChanges).toHaveLength(2);
+    expect(result!.fileChanges[0]).toEqual({
+      oldFilePath: "src/new1.ts",
+      newFilePath: "src/new1.ts",
+      type: "A",
+      additions: null,
+      deletions: null
+    });
+    expect(result!.fileChanges[1]).toEqual({
+      oldFilePath: "src/new2.ts",
+      newFilePath: "src/new2.ts",
+      type: "A",
+      additions: null,
+      deletions: null
+    });
+  });
+
+  it("deduplicates untracked files already present in diff output (TC-UD-B-02)", async () => {
+    // Given: diff has a file, ls-files also lists the same file
+    const nameStatus = "A\tsrc/file.ts\n";
+    const numStat = "10\t0\tsrc/file.ts\n";
+    const untracked = "src/file.ts\n";
+    setupSpawnForUncommitted(nameStatus, numStat, untracked);
+
+    // When: getUncommittedDetails is called
+    const result = await ds.getUncommittedDetails(REPO);
+
+    // Then: file appears only once (fileLookup prevents duplicate)
+    expect(result).not.toBeNull();
+    expect(result!.fileChanges).toHaveLength(1);
+    expect(result!.fileChanges[0].type).toBe("A");
+    expect(result!.fileChanges[0].additions).toBe(10);
+  });
+
+  it("skips empty lines in ls-files output (TC-UD-B-03)", async () => {
+    // Given: ls-files output has empty lines mixed in
+    const nameStatus = "";
+    const numStat = "";
+    const untracked = "src/a.ts\n\nsrc/b.ts\n";
+    setupSpawnForUncommitted(nameStatus, numStat, untracked);
+
+    // When: getUncommittedDetails is called
+    const result = await ds.getUncommittedDetails(REPO);
+
+    // Then: empty lines are skipped, only valid paths are added
+    expect(result).not.toBeNull();
+    expect(result!.fileChanges).toHaveLength(2);
+    expect(result!.fileChanges[0].newFilePath).toBe("src/a.ts");
+    expect(result!.fileChanges[1].newFilePath).toBe("src/b.ts");
+  });
+
+  it("returns null when spawn throws an exception (TC-UD-A-01)", async () => {
+    // Given: cp.spawn throws synchronously
+    spawnMock.mockImplementation(() => {
+      throw new Error("spawn ENOENT");
+    });
+
+    // When: getUncommittedDetails is called
+    const result = await ds.getUncommittedDetails(REPO);
+
+    // Then: Returns null (caught by try-catch block)
+    expect(result).toBeNull();
+  });
+
+  it("parses renamed files correctly in diff output (TC-UD-N-03)", async () => {
+    // Given: diff has a renamed file with R status
+    const nameStatus = "R100\tsrc/old.ts\tsrc/new.ts\n";
+    const numStat = "2\t1\tsrc/{old.ts => new.ts}\n";
+    const untracked = "";
+    setupSpawnForUncommitted(nameStatus, numStat, untracked);
+
+    // When: getUncommittedDetails is called
+    const result = await ds.getUncommittedDetails(REPO);
+
+    // Then: GitCommitDetails is returned with correct hash and file change data
+    expect(result).not.toBeNull();
+    expect(result!.hash).toBe(UNCOMMITTED_CHANGES_HASH);
+    expect(result!.fileChanges).toHaveLength(1);
+    expect(result!.fileChanges[0].oldFilePath).toBe("src/old.ts");
+    expect(result!.fileChanges[0].newFilePath).toBe("src/new.ts");
+    expect(result!.fileChanges[0].type).toBe("R");
+    expect(result!.fileChanges[0].additions).toBe(2);
+    expect(result!.fileChanges[0].deletions).toBe(1);
+  });
+});

--- a/tests/src/gitGraphView.test.ts
+++ b/tests/src/gitGraphView.test.ts
@@ -1,0 +1,559 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  postMessage: vi.fn(),
+  applyStash: vi.fn(),
+  popStash: vi.fn(),
+  dropStash: vi.fn(),
+  branchFromStash: vi.fn(),
+  pushStash: vi.fn(),
+  resetUncommitted: vi.fn(),
+  cleanUntrackedFiles: vi.fn(),
+  getCommitComparison: vi.fn(),
+  executeCommand: vi.fn(),
+  encodeDiffDocUri: vi.fn(),
+  mute: vi.fn(),
+  unmute: vi.fn(),
+  getRepos: vi.fn(),
+  messageHandler: { current: null as ((msg: unknown) => Promise<void>) | null }
+}));
+
+vi.mock("vscode", () => ({
+  window: {
+    createWebviewPanel: vi.fn(() => ({
+      webview: {
+        onDidReceiveMessage: vi.fn((handler: (msg: unknown) => Promise<void>) => {
+          mocks.messageHandler.current = handler;
+        }),
+        postMessage: mocks.postMessage,
+        asWebviewUri: vi.fn((uri: unknown) => uri),
+        cspSource: "test-csp",
+        html: ""
+      },
+      onDidDispose: vi.fn(),
+      onDidChangeViewState: vi.fn(),
+      reveal: vi.fn(),
+      visible: true,
+      iconPath: null,
+      dispose: vi.fn()
+    })),
+    activeTextEditor: undefined
+  },
+  Uri: {
+    file: vi.fn((p: string) => ({ fsPath: p, toString: () => p }))
+  },
+  ViewColumn: { One: 1 },
+  commands: { executeCommand: mocks.executeCommand }
+}));
+
+vi.mock("node:crypto", () => ({
+  randomBytes: vi.fn(() => ({ toString: () => "test-nonce" }))
+}));
+
+vi.mock("../../src/config", () => ({
+  getConfig: vi.fn(() => ({
+    gitPath: () => "git",
+    dateType: () => "Author Date",
+    showUncommittedChanges: () => false,
+    tabIconColourTheme: () => "colour",
+    autoCenterCommitDetailsView: () => false,
+    dateFormat: () => "Date & Time",
+    fetchAvatars: () => false,
+    graphColours: () => ["#0085d9"],
+    graphStyle: () => "rounded",
+    initialLoadCommits: () => 300,
+    loadMoreCommits: () => 100,
+    showCurrentBranchByDefault: () => false
+  }))
+}));
+
+vi.mock("../../src/repoFileWatcher", () => {
+  function MockRepoFileWatcher() {
+    return {
+      mute: mocks.mute,
+      unmute: mocks.unmute,
+      start: vi.fn(),
+      stop: vi.fn()
+    };
+  }
+  return { RepoFileWatcher: MockRepoFileWatcher };
+});
+
+vi.mock("../../src/diffDocProvider", () => ({
+  encodeDiffDocUri: mocks.encodeDiffDocUri
+}));
+
+vi.mock("../../src/utils", () => ({
+  abbrevCommit: vi.fn((h: string) => h.substring(0, 8)),
+  copyToClipboard: vi.fn()
+}));
+
+import type { AvatarManager } from "../../src/avatarManager";
+import type { DataSource } from "../../src/dataSource";
+import type { ExtensionState } from "../../src/extensionState";
+import { GitGraphView } from "../../src/gitGraphView";
+import type { RepoManager } from "../../src/repoManager";
+
+const TEST_REPO = "/test/repo";
+
+describe("GitGraphView stash message routing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.messageHandler.current = null;
+    GitGraphView.currentPanel = undefined;
+
+    mocks.getRepos.mockReturnValue({ [TEST_REPO]: "Test Repo" });
+    mocks.applyStash.mockResolvedValue(null);
+    mocks.popStash.mockResolvedValue(null);
+    mocks.dropStash.mockResolvedValue(null);
+    mocks.branchFromStash.mockResolvedValue(null);
+    mocks.pushStash.mockResolvedValue(null);
+    mocks.resetUncommitted.mockResolvedValue(null);
+    mocks.cleanUntrackedFiles.mockResolvedValue(null);
+    mocks.getCommitComparison.mockResolvedValue(null);
+    mocks.executeCommand.mockResolvedValue(undefined);
+    mocks.encodeDiffDocUri.mockImplementation(
+      (_repo: string, filePath: string, commit: string) => ({
+        toString: () => `git-keizu:${filePath}?commit=${commit}`
+      })
+    );
+
+    const mockDataSource = {
+      applyStash: mocks.applyStash,
+      popStash: mocks.popStash,
+      dropStash: mocks.dropStash,
+      branchFromStash: mocks.branchFromStash,
+      pushStash: mocks.pushStash,
+      resetUncommitted: mocks.resetUncommitted,
+      cleanUntrackedFiles: mocks.cleanUntrackedFiles,
+      getCommitComparison: mocks.getCommitComparison
+    } as unknown as DataSource;
+
+    const mockExtensionState = {
+      getLastActiveRepo: vi.fn(() => null),
+      isAvatarStorageAvailable: vi.fn(() => false),
+      setLastActiveRepo: vi.fn()
+    } as unknown as ExtensionState;
+
+    const mockAvatarManager = {
+      registerView: vi.fn(),
+      deregisterView: vi.fn()
+    } as unknown as AvatarManager;
+
+    const mockRepoManager = {
+      getRepos: mocks.getRepos,
+      registerViewCallback: vi.fn(),
+      deregisterViewCallback: vi.fn(),
+      setRepoState: vi.fn(),
+      checkReposExist: vi.fn()
+    } as unknown as RepoManager;
+
+    GitGraphView.createOrShow(
+      "/test/extension",
+      mockDataSource,
+      mockExtensionState,
+      mockAvatarManager,
+      mockRepoManager
+    );
+  });
+
+  afterEach(() => {
+    GitGraphView.currentPanel?.dispose();
+    GitGraphView.currentPanel = undefined;
+  });
+
+  it("routes applyStash message to DataSource.applyStash (TC-BS-N-07)", async () => {
+    // Given: GitGraphView instance with mocked DataSource
+    // When: RequestApplyStash message is received
+    await mocks.messageHandler.current!({
+      command: "applyStash",
+      repo: TEST_REPO,
+      selector: "stash@{0}",
+      reinstateIndex: true
+    });
+
+    // Then: DataSource.applyStash is called with correct arguments
+    expect(mocks.applyStash).toHaveBeenCalledTimes(1);
+    expect(mocks.applyStash).toHaveBeenCalledWith(TEST_REPO, "stash@{0}", true);
+    expect(mocks.mute).toHaveBeenCalled();
+    expect(mocks.unmute).toHaveBeenCalled();
+    expect(mocks.postMessage).toHaveBeenCalledWith({
+      command: "applyStash",
+      status: null
+    });
+  });
+
+  it("routes popStash message to DataSource.popStash (TC-BS-N-08)", async () => {
+    // Given: GitGraphView instance with mocked DataSource
+    // When: RequestPopStash message is received
+    await mocks.messageHandler.current!({
+      command: "popStash",
+      repo: TEST_REPO,
+      selector: "stash@{1}",
+      reinstateIndex: false
+    });
+
+    // Then: DataSource.popStash is called with correct arguments
+    expect(mocks.popStash).toHaveBeenCalledTimes(1);
+    expect(mocks.popStash).toHaveBeenCalledWith(TEST_REPO, "stash@{1}", false);
+    expect(mocks.postMessage).toHaveBeenCalledWith({
+      command: "popStash",
+      status: null
+    });
+  });
+
+  it("routes dropStash message to DataSource.dropStash (TC-BS-N-09)", async () => {
+    // Given: GitGraphView instance with mocked DataSource
+    // When: RequestDropStash message is received
+    await mocks.messageHandler.current!({
+      command: "dropStash",
+      repo: TEST_REPO,
+      selector: "stash@{2}"
+    });
+
+    // Then: DataSource.dropStash is called with correct arguments
+    expect(mocks.dropStash).toHaveBeenCalledTimes(1);
+    expect(mocks.dropStash).toHaveBeenCalledWith(TEST_REPO, "stash@{2}");
+    expect(mocks.postMessage).toHaveBeenCalledWith({
+      command: "dropStash",
+      status: null
+    });
+  });
+
+  it("routes branchFromStash message to DataSource.branchFromStash (TC-BS-N-10)", async () => {
+    // Given: GitGraphView instance with mocked DataSource
+    // When: RequestBranchFromStash message is received
+    await mocks.messageHandler.current!({
+      command: "branchFromStash",
+      repo: TEST_REPO,
+      branchName: "my-feature",
+      selector: "stash@{0}"
+    });
+
+    // Then: DataSource.branchFromStash is called with correct arguments
+    expect(mocks.branchFromStash).toHaveBeenCalledTimes(1);
+    expect(mocks.branchFromStash).toHaveBeenCalledWith(TEST_REPO, "my-feature", "stash@{0}");
+    expect(mocks.postMessage).toHaveBeenCalledWith({
+      command: "branchFromStash",
+      status: null
+    });
+  });
+
+  it("routes pushStash message to DataSource.pushStash (TC-BU-N-08)", async () => {
+    // Given: GitGraphView instance with mocked DataSource
+    // When: RequestPushStash message is received
+    await mocks.messageHandler.current!({
+      command: "pushStash",
+      repo: TEST_REPO,
+      message: "WIP changes",
+      includeUntracked: true
+    });
+
+    // Then: DataSource.pushStash is called with correct arguments
+    expect(mocks.pushStash).toHaveBeenCalledTimes(1);
+    expect(mocks.pushStash).toHaveBeenCalledWith(TEST_REPO, "WIP changes", true);
+    expect(mocks.mute).toHaveBeenCalled();
+    expect(mocks.unmute).toHaveBeenCalled();
+    expect(mocks.postMessage).toHaveBeenCalledWith({
+      command: "pushStash",
+      status: null
+    });
+  });
+
+  it("routes resetUncommitted message to DataSource.resetUncommitted (TC-BU-N-09)", async () => {
+    // Given: GitGraphView instance with mocked DataSource
+    // When: RequestResetUncommitted message is received
+    await mocks.messageHandler.current!({
+      command: "resetUncommitted",
+      repo: TEST_REPO,
+      mode: "mixed"
+    });
+
+    // Then: DataSource.resetUncommitted is called with correct arguments
+    expect(mocks.resetUncommitted).toHaveBeenCalledTimes(1);
+    expect(mocks.resetUncommitted).toHaveBeenCalledWith(TEST_REPO, "mixed");
+    expect(mocks.mute).toHaveBeenCalled();
+    expect(mocks.unmute).toHaveBeenCalled();
+    expect(mocks.postMessage).toHaveBeenCalledWith({
+      command: "resetUncommitted",
+      status: null
+    });
+  });
+
+  it("routes cleanUntrackedFiles message to DataSource.cleanUntrackedFiles (TC-BU-N-10)", async () => {
+    // Given: GitGraphView instance with mocked DataSource
+    // When: RequestCleanUntrackedFiles message is received
+    await mocks.messageHandler.current!({
+      command: "cleanUntrackedFiles",
+      repo: TEST_REPO,
+      directories: true
+    });
+
+    // Then: DataSource.cleanUntrackedFiles is called with correct arguments
+    expect(mocks.cleanUntrackedFiles).toHaveBeenCalledTimes(1);
+    expect(mocks.cleanUntrackedFiles).toHaveBeenCalledWith(TEST_REPO, true);
+    expect(mocks.mute).toHaveBeenCalled();
+    expect(mocks.unmute).toHaveBeenCalled();
+    expect(mocks.postMessage).toHaveBeenCalledWith({
+      command: "cleanUntrackedFiles",
+      status: null
+    });
+  });
+});
+
+describe("GitGraphView compareCommits message routing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.messageHandler.current = null;
+    GitGraphView.currentPanel = undefined;
+
+    mocks.getRepos.mockReturnValue({ [TEST_REPO]: "Test Repo" });
+    mocks.getCommitComparison.mockResolvedValue(null);
+    mocks.executeCommand.mockResolvedValue(undefined);
+    mocks.encodeDiffDocUri.mockImplementation(
+      (_repo: string, filePath: string, commit: string) => ({
+        toString: () => `git-keizu:${filePath}?commit=${commit}`
+      })
+    );
+
+    const mockDataSource = {
+      applyStash: mocks.applyStash,
+      popStash: mocks.popStash,
+      dropStash: mocks.dropStash,
+      branchFromStash: mocks.branchFromStash,
+      pushStash: mocks.pushStash,
+      resetUncommitted: mocks.resetUncommitted,
+      cleanUntrackedFiles: mocks.cleanUntrackedFiles,
+      getCommitComparison: mocks.getCommitComparison
+    } as unknown as DataSource;
+
+    const mockExtensionState = {
+      getLastActiveRepo: vi.fn(() => null),
+      isAvatarStorageAvailable: vi.fn(() => false),
+      setLastActiveRepo: vi.fn()
+    } as unknown as ExtensionState;
+
+    const mockAvatarManager = {
+      registerView: vi.fn(),
+      deregisterView: vi.fn()
+    } as unknown as AvatarManager;
+
+    const mockRepoManager = {
+      getRepos: mocks.getRepos,
+      registerViewCallback: vi.fn(),
+      deregisterViewCallback: vi.fn(),
+      setRepoState: vi.fn(),
+      checkReposExist: vi.fn()
+    } as unknown as RepoManager;
+
+    GitGraphView.createOrShow(
+      "/test/extension",
+      mockDataSource,
+      mockExtensionState,
+      mockAvatarManager,
+      mockRepoManager
+    );
+  });
+
+  afterEach(() => {
+    GitGraphView.currentPanel?.dispose();
+    GitGraphView.currentPanel = undefined;
+  });
+
+  it("routes compareCommits message to DataSource.getCommitComparison with correct args (TC-MR-N-01)", async () => {
+    // Given: GitGraphView instance with mocked DataSource
+    const fromHash = "abc1234567890abcdef1234567890abcdef123456";
+    const toHash = "def4567890abcdef1234567890abcdef12345678";
+
+    // When: RequestCompareCommits message is received
+    await mocks.messageHandler.current!({
+      command: "compareCommits",
+      repo: TEST_REPO,
+      fromHash,
+      toHash
+    });
+
+    // Then: DataSource.getCommitComparison is called with repo, fromHash, toHash
+    expect(mocks.getCommitComparison).toHaveBeenCalledTimes(1);
+    expect(mocks.getCommitComparison).toHaveBeenCalledWith(TEST_REPO, fromHash, toHash);
+  });
+
+  it("returns ResponseCompareCommits with fileChanges when comparison succeeds (TC-MR-N-02)", async () => {
+    // Given: getCommitComparison returns a file change array
+    const fromHash = "abc1234567890abcdef1234567890abcdef123456";
+    const toHash = "def4567890abcdef1234567890abcdef12345678";
+    const fileChanges = [
+      {
+        oldFilePath: "src/file.ts",
+        newFilePath: "src/file.ts",
+        type: "M" as const,
+        additions: 10,
+        deletions: 5
+      }
+    ];
+    mocks.getCommitComparison.mockResolvedValue(fileChanges);
+
+    // When: RequestCompareCommits message is received
+    await mocks.messageHandler.current!({
+      command: "compareCommits",
+      repo: TEST_REPO,
+      fromHash,
+      toHash
+    });
+
+    // Then: ResponseCompareCommits is sent with correct fileChanges, fromHash, toHash
+    expect(mocks.postMessage).toHaveBeenCalledWith({
+      command: "compareCommits",
+      fileChanges,
+      fromHash,
+      toHash
+    });
+  });
+
+  it("returns ResponseCompareCommits with null fileChanges when comparison fails (TC-MR-A-01)", async () => {
+    // Given: getCommitComparison returns null (error case)
+    const fromHash = "abc1234567890abcdef1234567890abcdef123456";
+    const toHash = "def4567890abcdef1234567890abcdef12345678";
+    mocks.getCommitComparison.mockResolvedValue(null);
+
+    // When: RequestCompareCommits message is received
+    await mocks.messageHandler.current!({
+      command: "compareCommits",
+      repo: TEST_REPO,
+      fromHash,
+      toHash
+    });
+
+    // Then: ResponseCompareCommits is sent with null fileChanges
+    expect(mocks.postMessage).toHaveBeenCalledWith({
+      command: "compareCommits",
+      fileChanges: null,
+      fromHash,
+      toHash
+    });
+  });
+});
+
+describe("GitGraphView viewDiff with compareWithHash", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.messageHandler.current = null;
+    GitGraphView.currentPanel = undefined;
+
+    mocks.getRepos.mockReturnValue({ [TEST_REPO]: "Test Repo" });
+    mocks.getCommitComparison.mockResolvedValue(null);
+    mocks.executeCommand.mockResolvedValue(undefined);
+    mocks.encodeDiffDocUri.mockImplementation(
+      (_repo: string, filePath: string, commit: string) => ({
+        toString: () => `git-keizu:${filePath}?commit=${commit}`
+      })
+    );
+
+    const mockDataSource = {
+      applyStash: mocks.applyStash,
+      popStash: mocks.popStash,
+      dropStash: mocks.dropStash,
+      branchFromStash: mocks.branchFromStash,
+      pushStash: mocks.pushStash,
+      resetUncommitted: mocks.resetUncommitted,
+      cleanUntrackedFiles: mocks.cleanUntrackedFiles,
+      getCommitComparison: mocks.getCommitComparison
+    } as unknown as DataSource;
+
+    const mockExtensionState = {
+      getLastActiveRepo: vi.fn(() => null),
+      isAvatarStorageAvailable: vi.fn(() => false),
+      setLastActiveRepo: vi.fn()
+    } as unknown as ExtensionState;
+
+    const mockAvatarManager = {
+      registerView: vi.fn(),
+      deregisterView: vi.fn()
+    } as unknown as AvatarManager;
+
+    const mockRepoManager = {
+      getRepos: mocks.getRepos,
+      registerViewCallback: vi.fn(),
+      deregisterViewCallback: vi.fn(),
+      setRepoState: vi.fn(),
+      checkReposExist: vi.fn()
+    } as unknown as RepoManager;
+
+    GitGraphView.createOrShow(
+      "/test/extension",
+      mockDataSource,
+      mockExtensionState,
+      mockAvatarManager,
+      mockRepoManager
+    );
+  });
+
+  afterEach(() => {
+    GitGraphView.currentPanel?.dispose();
+    GitGraphView.currentPanel = undefined;
+  });
+
+  it("generates correct URIs for two-commit comparison when compareWithHash is specified (TC-MR-N-03)", async () => {
+    // Given: viewDiff message with compareWithHash
+    const commitHash = "abc1234567890abcdef1234567890abcdef123456";
+    const compareWithHash = "def4567890abcdef1234567890abcdef12345678";
+
+    // When: RequestViewDiff message with compareWithHash is received
+    await mocks.messageHandler.current!({
+      command: "viewDiff",
+      repo: TEST_REPO,
+      commitHash,
+      oldFilePath: "src/old.ts",
+      newFilePath: "src/new.ts",
+      type: "M",
+      compareWithHash
+    });
+
+    // Then: encodeDiffDocUri is called for both left (fromHash) and right (compareWithHash) URIs
+    expect(mocks.encodeDiffDocUri).toHaveBeenCalledTimes(2);
+    expect(mocks.encodeDiffDocUri).toHaveBeenCalledWith(TEST_REPO, "src/old.ts", commitHash);
+    expect(mocks.encodeDiffDocUri).toHaveBeenCalledWith(TEST_REPO, "src/new.ts", compareWithHash);
+
+    // Then: vscode.diff command is executed with the generated URIs
+    expect(mocks.executeCommand).toHaveBeenCalledTimes(1);
+    expect(mocks.executeCommand).toHaveBeenCalledWith(
+      "vscode.diff",
+      expect.objectContaining({ toString: expect.any(Function) }),
+      expect.objectContaining({ toString: expect.any(Function) }),
+      expect.stringContaining("↔"),
+      { preview: true }
+    );
+
+    // Then: Response indicates success
+    expect(mocks.postMessage).toHaveBeenCalledWith({
+      command: "viewDiff",
+      success: true
+    });
+  });
+
+  it("maintains existing behavior when compareWithHash is not specified (TC-MR-N-04)", async () => {
+    // Given: viewDiff message without compareWithHash (standard parent comparison)
+    const commitHash = "abc1234567890abcdef1234567890abcdef123456";
+
+    // When: RequestViewDiff message without compareWithHash is received
+    await mocks.messageHandler.current!({
+      command: "viewDiff",
+      repo: TEST_REPO,
+      commitHash,
+      oldFilePath: "src/file.ts",
+      newFilePath: "src/file.ts",
+      type: "M"
+    });
+
+    // Then: encodeDiffDocUri is called with commitHash^ and commitHash (parent comparison)
+    expect(mocks.encodeDiffDocUri).toHaveBeenCalledTimes(2);
+    expect(mocks.encodeDiffDocUri).toHaveBeenCalledWith(TEST_REPO, "src/file.ts", `${commitHash}^`);
+    expect(mocks.encodeDiffDocUri).toHaveBeenCalledWith(TEST_REPO, "src/file.ts", commitHash);
+
+    // Then: Response indicates success
+    expect(mocks.postMessage).toHaveBeenCalledWith({
+      command: "viewDiff",
+      success: true
+    });
+  });
+});

--- a/tests/src/types.test.ts
+++ b/tests/src/types.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { UNCOMMITTED_CHANGES_HASH, VALID_UNCOMMITTED_RESET_MODES } from "../../src/types";
+
+describe("UNCOMMITTED_CHANGES_HASH", () => {
+  it("equals '*' for backward compatibility (TC-F-N-01)", () => {
+    // Given: UNCOMMITTED_CHANGES_HASH is imported
+    // When: its value is referenced
+    // Then: it matches "*"
+    expect(UNCOMMITTED_CHANGES_HASH).toBe("*");
+  });
+});
+
+describe("VALID_UNCOMMITTED_RESET_MODES", () => {
+  it('includes "mixed" (TC-F-N-02)', () => {
+    // Given: VALID_UNCOMMITTED_RESET_MODES is imported
+    // When: has() is called with "mixed"
+    // Then: returns true
+    expect(VALID_UNCOMMITTED_RESET_MODES.has("mixed")).toBe(true);
+  });
+
+  it('includes "hard" (TC-F-N-03)', () => {
+    // Given: VALID_UNCOMMITTED_RESET_MODES is imported
+    // When: has() is called with "hard"
+    // Then: returns true
+    expect(VALID_UNCOMMITTED_RESET_MODES.has("hard")).toBe(true);
+  });
+
+  it("contains exactly 2 modes (TC-F-B-01)", () => {
+    // Given: VALID_UNCOMMITTED_RESET_MODES is imported
+    // When: its size is checked
+    // Then: it equals 2
+    expect(VALID_UNCOMMITTED_RESET_MODES.size).toBe(2);
+  });
+
+  it('rejects "soft" as an invalid mode (TC-F-A-01)', () => {
+    // Given: VALID_UNCOMMITTED_RESET_MODES is imported
+    // When: has() is called with "soft"
+    // Then: returns false (soft is not valid for uncommitted reset)
+    expect(VALID_UNCOMMITTED_RESET_MODES.has("soft")).toBe(false);
+  });
+
+  it("rejects empty string (TC-F-A-02)", () => {
+    // Given: VALID_UNCOMMITTED_RESET_MODES is imported
+    // When: has() is called with ""
+    // Then: returns false
+    expect(VALID_UNCOMMITTED_RESET_MODES.has("")).toBe(false);
+  });
+
+  it('rejects uppercase "MIXED" (TC-F-A-03)', () => {
+    // Given: VALID_UNCOMMITTED_RESET_MODES is imported
+    // When: has() is called with "MIXED"
+    // Then: returns false (case-sensitive matching)
+    expect(VALID_UNCOMMITTED_RESET_MODES.has("MIXED")).toBe(false);
+  });
+});

--- a/tests/web/findWidget.test.ts
+++ b/tests/web/findWidget.test.ts
@@ -1,0 +1,645 @@
+// @vitest-environment jsdom
+import type { Mock } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type * as GG from "../../src/types";
+import type { FindWidgetCallbacks } from "../../web/findWidget";
+import {
+  CLASS_FIND_CURRENT_COMMIT,
+  CLASS_FIND_MATCH,
+  FindWidget,
+  SEARCH_DEBOUNCE_MS
+} from "../../web/findWidget";
+
+/* === Mocks === */
+
+vi.mock("../../web/branchLabels", () => ({
+  getBranchLabels: vi.fn(() => ({ heads: [], remotes: [], tags: [] }))
+}));
+
+vi.mock("../../web/dates", () => ({
+  getCommitDate: vi.fn(() => ({ title: "24 Feb 2026 12:00", value: "24 Feb 2026 12:00" }))
+}));
+
+import { getBranchLabels } from "../../web/branchLabels";
+
+/* === Helpers === */
+
+const ABBREV_LENGTH = 8;
+
+function createMockCallbacks(): FindWidgetCallbacks {
+  return {
+    getCommits: vi.fn(() => []),
+    getColumnVisibility: vi.fn(() => ({ author: true, date: true, commit: true })),
+    scrollToCommit: vi.fn(),
+    saveState: vi.fn(),
+    loadCommitDetails: vi.fn(),
+    getCommitId: vi.fn(() => null),
+    isCdvOpen: vi.fn(() => false)
+  };
+}
+
+function makeCommit(overrides: Partial<GG.GitCommitNode> & { hash: string }): GG.GitCommitNode {
+  return {
+    parentHashes: [],
+    author: "Author",
+    email: "author@example.com",
+    date: 1708790400,
+    message: "commit message",
+    refs: [],
+    stash: null,
+    ...overrides
+  };
+}
+
+function createCommitRow(id: number, texts: string[]): HTMLElement {
+  const row = document.createElement("tr");
+  row.className = "commit";
+  row.dataset.id = id.toString();
+  for (const text of texts) {
+    const td = document.createElement("td");
+    td.textContent = text;
+    row.appendChild(td);
+  }
+  document.body.appendChild(row);
+  return row;
+}
+
+function setupCommitsAndDom(commits: GG.GitCommitNode[], callbacks: FindWidgetCallbacks): void {
+  (callbacks.getCommits as Mock).mockReturnValue(commits);
+  for (let i = 0; i < commits.length; i++) {
+    const c = commits[i];
+    createCommitRow(i, [c.message, c.author, c.hash.substring(0, ABBREV_LENGTH)]);
+  }
+}
+
+function triggerSearch(widget: FindWidget, text: string, options?: Partial<FindWidgetState>): void {
+  widget.restoreState({
+    text,
+    currentHash: null,
+    visible: true,
+    caseSensitive: options?.caseSensitive ?? false,
+    regex: options?.regex ?? false
+  });
+}
+
+function getPositionText(): string {
+  return document.getElementById("findPosition")!.textContent ?? "";
+}
+
+function getMatchSpans(): Element[] {
+  return Array.from(document.getElementsByClassName(CLASS_FIND_MATCH));
+}
+
+function getHighlightedRows(): Element[] {
+  return Array.from(document.getElementsByClassName(CLASS_FIND_CURRENT_COMMIT));
+}
+
+/* === Tests === */
+
+describe("FindWidget", () => {
+  let callbacks: FindWidgetCallbacks;
+  let widget: FindWidget;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    callbacks = createMockCallbacks();
+    widget = new FindWidget(callbacks);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  /* --- DOM generation and visibility --- */
+
+  describe("DOM generation and visibility", () => {
+    it("generates correct DOM structure on construction (TC-FW-N-01)", () => {
+      // Given: FindWidget is constructed
+      // When: DOM is inspected
+      // Then: all required elements exist
+      expect(document.querySelector(".findWidget")).not.toBeNull();
+      expect(document.getElementById("findInput")).not.toBeNull();
+      expect(document.getElementById("findCaseSensitive")).not.toBeNull();
+      expect(document.getElementById("findRegex")).not.toBeNull();
+      expect(document.getElementById("findPosition")).not.toBeNull();
+      expect(document.getElementById("findPrev")).not.toBeNull();
+      expect(document.getElementById("findNext")).not.toBeNull();
+      expect(document.getElementById("findOpenCdv")).not.toBeNull();
+      expect(document.getElementById("findClose")).not.toBeNull();
+    });
+
+    it("show() makes widget visible and focuses input (TC-FW-N-02)", () => {
+      // Given: widget is initially hidden
+      // When: show() is called
+      widget.show(false);
+
+      // Then: widget has active class and input is focused
+      const widgetElem = document.querySelector(".findWidget")!;
+      expect(widgetElem.classList.contains("active")).toBe(true);
+      expect(widget.isVisible()).toBe(true);
+      expect(document.activeElement).toBe(document.getElementById("findInput"));
+    });
+
+    it("close() hides widget and clears highlights (TC-FW-N-03)", () => {
+      // Given: widget is visible with matches
+      const commits = [makeCommit({ hash: "aaa1111100000000", message: "fix bug" })];
+      setupCommitsAndDom(commits, callbacks);
+      triggerSearch(widget, "fix");
+      expect(widget.isVisible()).toBe(true);
+
+      // When: close() is called
+      widget.close();
+
+      // Then: widget is hidden, matches are cleared, saveState is called
+      const widgetElem = document.querySelector(".findWidget")!;
+      expect(widgetElem.classList.contains("active")).toBe(false);
+      expect(widget.isVisible()).toBe(false);
+      expect(getMatchSpans()).toHaveLength(0);
+      expect(callbacks.saveState).toHaveBeenCalled();
+    });
+
+    it("isVisible() returns true after show() (TC-FW-N-04)", () => {
+      // Given: widget is hidden
+      // When: show() is called
+      widget.show(false);
+      // Then: isVisible() returns true
+      expect(widget.isVisible()).toBe(true);
+    });
+
+    it("isVisible() returns false after close() (TC-FW-N-05)", () => {
+      // Given: widget is visible
+      widget.show(false);
+      // When: close() is called
+      widget.close();
+      // Then: isVisible() returns false
+      expect(widget.isVisible()).toBe(false);
+    });
+  });
+
+  /* --- Input control --- */
+
+  describe("Input control", () => {
+    it("setInputEnabled(false) disables input when visible (TC-FW-N-06)", () => {
+      // Given: widget is visible
+      widget.show(false);
+      // When: setInputEnabled(false)
+      widget.setInputEnabled(false);
+      // Then: input is disabled
+      expect((document.getElementById("findInput") as HTMLInputElement).disabled).toBe(true);
+    });
+
+    it("setInputEnabled(true) enables input when visible (TC-FW-N-07)", () => {
+      // Given: widget is visible and input is disabled
+      widget.show(false);
+      widget.setInputEnabled(false);
+      // When: setInputEnabled(true)
+      widget.setInputEnabled(true);
+      // Then: input is enabled
+      expect((document.getElementById("findInput") as HTMLInputElement).disabled).toBe(false);
+    });
+
+    it("search on zero commits shows no results (TC-FW-B-01)", () => {
+      // Given: no commits exist
+      (callbacks.getCommits as Mock).mockReturnValue([]);
+      // When: search is triggered
+      triggerSearch(widget, "anything");
+      // Then: counter shows No Results
+      expect(getPositionText()).toBe("No Results");
+      expect(getMatchSpans()).toHaveLength(0);
+    });
+  });
+
+  /* --- Search matching --- */
+
+  describe("Search matching", () => {
+    it("matches commit message text (TC-FW-N-08)", () => {
+      // Given: commit with message "fix bug" exists
+      const commits = [
+        makeCommit({ hash: "aaa1111100000000", message: "fix bug" }),
+        makeCommit({ hash: "bbb2222200000000", message: "add feature" })
+      ];
+      setupCommitsAndDom(commits, callbacks);
+
+      // When: search for "fix"
+      triggerSearch(widget, "fix");
+
+      // Then: one match found, counter shows "1 of 1"
+      expect(getPositionText()).toBe("1 of 1");
+    });
+
+    it("matches author name (TC-FW-N-09)", () => {
+      // Given: commit with author "Alice" exists
+      const commits = [
+        makeCommit({ hash: "aaa1111100000000", author: "Alice", message: "some change" }),
+        makeCommit({ hash: "bbb2222200000000", author: "Bob", message: "other change" })
+      ];
+      setupCommitsAndDom(commits, callbacks);
+
+      // When: search for "Alice"
+      triggerSearch(widget, "Alice");
+
+      // Then: one match found
+      expect(getPositionText()).toBe("1 of 1");
+    });
+
+    it("matches abbreviated commit hash (TC-FW-N-10)", () => {
+      // Given: commit with hash starting with "abc12345"
+      const commits = [
+        makeCommit({ hash: "abc1234567890abc", message: "change" }),
+        makeCommit({ hash: "def4567890123def", message: "other" })
+      ];
+      setupCommitsAndDom(commits, callbacks);
+
+      // When: search for "abc12345"
+      triggerSearch(widget, "abc12345");
+
+      // Then: one match found
+      expect(getPositionText()).toBe("1 of 1");
+    });
+
+    it("matches branch and tag names (TC-FW-N-11)", () => {
+      // Given: commit with branch ref "main"
+      const commits = [
+        makeCommit({
+          hash: "aaa1111100000000",
+          message: "change",
+          refs: [{ hash: "aaa1111100000000", name: "main", type: "head" }]
+        }),
+        makeCommit({ hash: "bbb2222200000000", message: "other" })
+      ];
+      setupCommitsAndDom(commits, callbacks);
+      (getBranchLabels as Mock).mockImplementation((refs: GG.GitRef[]) => ({
+        heads: refs.filter((r) => r.type === "head").map((r) => ({ name: r.name, remotes: [] })),
+        remotes: refs.filter((r) => r.type === "remote"),
+        tags: refs.filter((r) => r.type === "tag")
+      }));
+
+      // When: search for "main"
+      triggerSearch(widget, "main");
+
+      // Then: one match found
+      expect(getPositionText()).toBe("1 of 1");
+    });
+
+    it("shows correct match count for multiple matches (TC-FW-N-12)", () => {
+      // Given: 3 commits matching "fix"
+      const commits = [
+        makeCommit({ hash: "aaa1111100000000", message: "fix bug A" }),
+        makeCommit({ hash: "bbb2222200000000", message: "fix bug B" }),
+        makeCommit({ hash: "ccc3333300000000", message: "fix bug C" })
+      ];
+      setupCommitsAndDom(commits, callbacks);
+
+      // When: search for "fix"
+      triggerSearch(widget, "fix");
+
+      // Then: counter shows "1 of 3" (initial position is 1)
+      expect(getPositionText()).toBe("1 of 3");
+    });
+
+    it("shows No Results for zero matches (TC-FW-B-02)", () => {
+      // Given: commits exist but none match
+      const commits = [makeCommit({ hash: "aaa1111100000000", message: "add feature" })];
+      setupCommitsAndDom(commits, callbacks);
+
+      // When: search for "nonexistent"
+      triggerSearch(widget, "nonexistent");
+
+      // Then: counter shows "No Results"
+      expect(getPositionText()).toBe("No Results");
+      expect(getHighlightedRows()).toHaveLength(0);
+    });
+
+    it("shows 1 of 1 for single match (TC-FW-B-03)", () => {
+      // Given: exactly one matching commit
+      const commits = [
+        makeCommit({ hash: "aaa1111100000000", message: "unique text" }),
+        makeCommit({ hash: "bbb2222200000000", message: "other" })
+      ];
+      setupCommitsAndDom(commits, callbacks);
+
+      // When: search for "unique"
+      triggerSearch(widget, "unique");
+
+      // Then: counter shows "1 of 1"
+      expect(getPositionText()).toBe("1 of 1");
+    });
+
+    it("clears highlights when search text is emptied (TC-FW-B-04)", () => {
+      vi.useFakeTimers();
+      try {
+        // Given: search active with matches
+        const commits = [makeCommit({ hash: "aaa1111100000000", message: "fix bug" })];
+        setupCommitsAndDom(commits, callbacks);
+        triggerSearch(widget, "fix");
+        expect(getPositionText()).toBe("1 of 1");
+
+        // When: user clears the input text
+        const inputElem = document.getElementById("findInput") as HTMLInputElement;
+        inputElem.value = "";
+        inputElem.dispatchEvent(new KeyboardEvent("keyup", { key: "Backspace" }));
+        vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+
+        // Then: all highlights removed, counter shows No Results
+        expect(getMatchSpans()).toHaveLength(0);
+        expect(getPositionText()).toBe("No Results");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  /* --- Search options --- */
+
+  describe("Search options", () => {
+    it("case insensitive by default (TC-FW-N-13)", () => {
+      // Given: commit with message "Fix bug"
+      const commits = [makeCommit({ hash: "aaa1111100000000", message: "Fix bug" })];
+      setupCommitsAndDom(commits, callbacks);
+
+      // When: search for "fix" (lowercase) with caseSensitive OFF
+      triggerSearch(widget, "fix", { caseSensitive: false });
+
+      // Then: matches "Fix" (case insensitive)
+      expect(getPositionText()).toBe("1 of 1");
+    });
+
+    it("case sensitive when enabled (TC-FW-N-14)", () => {
+      // Given: commits with "Fix" and "fix"
+      const commits = [
+        makeCommit({ hash: "aaa1111100000000", message: "Fix bug" }),
+        makeCommit({ hash: "bbb2222200000000", message: "fix issue" })
+      ];
+      setupCommitsAndDom(commits, callbacks);
+
+      // When: search for "Fix" with caseSensitive ON
+      triggerSearch(widget, "Fix", { caseSensitive: true });
+
+      // Then: only "Fix" matches, not "fix"
+      expect(getPositionText()).toBe("1 of 1");
+    });
+
+    it("regex mode matches patterns (TC-FW-N-15)", () => {
+      // Given: commits with "fix" and "feat" messages
+      const commits = [
+        makeCommit({ hash: "aaa1111100000000", message: "fix bug" }),
+        makeCommit({ hash: "bbb2222200000000", message: "feat: new" }),
+        makeCommit({ hash: "ccc3333300000000", message: "docs update" })
+      ];
+      setupCommitsAndDom(commits, callbacks);
+
+      // When: search for "fix|feat" in regex mode
+      triggerSearch(widget, "fix|feat", { regex: true });
+
+      // Then: two matches found
+      expect(getPositionText()).toBe("1 of 2");
+    });
+
+    it("invalid regex sets error attribute (TC-FW-A-01)", () => {
+      // Given: commits exist
+      const commits = [makeCommit({ hash: "aaa1111100000000", message: "test" })];
+      setupCommitsAndDom(commits, callbacks);
+
+      // When: search with invalid regex "[invalid"
+      triggerSearch(widget, "[invalid", { regex: true });
+
+      // Then: widget has data-error attribute, no matches
+      const widgetElem = document.querySelector(".findWidget")!;
+      expect(widgetElem.hasAttribute("data-error")).toBe(true);
+      expect(getPositionText()).toBe("No Results");
+    });
+
+    it("zero-length match sets error and clears matches (TC-FW-A-02)", () => {
+      // Given: commits exist
+      const commits = [makeCommit({ hash: "aaa1111100000000", message: "test data" })];
+      setupCommitsAndDom(commits, callbacks);
+
+      // When: search with zero-length pattern "(?:)" in regex mode
+      triggerSearch(widget, "(?:)", { regex: true });
+
+      // Then: error attribute set, matches cleared
+      const widgetElem = document.querySelector(".findWidget")!;
+      expect(widgetElem.hasAttribute("data-error")).toBe(true);
+      expect(getPositionText()).toBe("No Results");
+    });
+
+    it("potential ReDoS pattern does not crash (TC-FW-A-03)", () => {
+      // Given: commits exist
+      const commits = [makeCommit({ hash: "aaa1111100000000", message: "aaaaaa" })];
+      setupCommitsAndDom(commits, callbacks);
+
+      // When: search with potential ReDoS pattern "(a+)+"
+      // Then: no crash, search completes safely
+      expect(() => {
+        triggerSearch(widget, "(a+)+", { regex: true });
+      }).not.toThrow();
+    });
+  });
+
+  /* --- Navigation --- */
+
+  describe("Navigation", () => {
+    function setupThreeMatches(): void {
+      const commits = [
+        makeCommit({ hash: "aaa1111100000000", message: "fix A" }),
+        makeCommit({ hash: "bbb2222200000000", message: "fix B" }),
+        makeCommit({ hash: "ccc3333300000000", message: "fix C" })
+      ];
+      setupCommitsAndDom(commits, callbacks);
+      triggerSearch(widget, "fix");
+    }
+
+    it("next() advances position (TC-FW-N-16)", () => {
+      // Given: 3 matches, position at 1
+      setupThreeMatches();
+      expect(getPositionText()).toBe("1 of 3");
+
+      // When: click next button
+      document.getElementById("findNext")!.click();
+
+      // Then: position is 2
+      expect(getPositionText()).toBe("2 of 3");
+    });
+
+    it("prev() wraps to last position (TC-FW-N-17)", () => {
+      // Given: 3 matches, position at 1
+      setupThreeMatches();
+      expect(getPositionText()).toBe("1 of 3");
+
+      // When: click prev button
+      document.getElementById("findPrev")!.click();
+
+      // Then: position wraps to 3 (last)
+      expect(getPositionText()).toBe("3 of 3");
+    });
+
+    it("next() wraps from last to first (TC-FW-B-05)", () => {
+      // Given: 3 matches, position at 3
+      setupThreeMatches();
+      document.getElementById("findPrev")!.click(); // go to 3
+      expect(getPositionText()).toBe("3 of 3");
+
+      // When: click next
+      document.getElementById("findNext")!.click();
+
+      // Then: wraps to 1
+      expect(getPositionText()).toBe("1 of 3");
+    });
+
+    it("next() with zero matches does nothing (TC-FW-B-06)", () => {
+      // Given: no matches
+      const commits = [makeCommit({ hash: "aaa1111100000000", message: "other" })];
+      setupCommitsAndDom(commits, callbacks);
+      triggerSearch(widget, "nonexistent");
+      expect(getPositionText()).toBe("No Results");
+
+      // When: click next
+      document.getElementById("findNext")!.click();
+
+      // Then: still No Results, no error
+      expect(getPositionText()).toBe("No Results");
+    });
+
+    it("navigation triggers scrollToCommit (TC-FW-N-18)", () => {
+      // Given: matches exist
+      setupThreeMatches();
+      (callbacks.scrollToCommit as Mock).mockClear();
+
+      // When: click next
+      document.getElementById("findNext")!.click();
+
+      // Then: scrollToCommit is called
+      expect(callbacks.scrollToCommit).toHaveBeenCalledTimes(1);
+      expect(callbacks.scrollToCommit).toHaveBeenCalledWith("bbb2222200000000", false);
+    });
+  });
+
+  /* --- State persistence --- */
+
+  describe("State persistence", () => {
+    it("getState() returns current FindWidgetState (TC-FW-N-19)", () => {
+      // Given: widget is visible with specific settings
+      widget.restoreState({
+        text: "search term",
+        currentHash: null,
+        visible: true,
+        caseSensitive: true,
+        regex: false
+      });
+
+      // When: getState() is called
+      const state = widget.getState();
+
+      // Then: state contains all fields
+      expect(state.text).toBe("search term");
+      expect(state.visible).toBe(true);
+      expect(state.caseSensitive).toBe(true);
+      expect(state.regex).toBe(false);
+    });
+
+    it("restoreState() restores saved state correctly (TC-FW-N-20)", () => {
+      // Given: a saved state
+      const savedState: FindWidgetState = {
+        text: "restored",
+        currentHash: null,
+        visible: true,
+        caseSensitive: true,
+        regex: true
+      };
+
+      // When: restoreState() is called
+      widget.restoreState(savedState);
+
+      // Then: state is restored
+      const state = widget.getState();
+      expect(state.text).toBe("restored");
+      expect(state.visible).toBe(true);
+      expect(state.caseSensitive).toBe(true);
+      expect(state.regex).toBe(true);
+      expect(widget.isVisible()).toBe(true);
+    });
+
+    it("restoreState with non-visible state does not activate widget (TC-FW-B-07)", () => {
+      // Given: state with visible: false
+      const state: FindWidgetState = {
+        text: "test",
+        currentHash: null,
+        visible: false,
+        caseSensitive: false,
+        regex: false
+      };
+
+      // When: restoreState() is called
+      widget.restoreState(state);
+
+      // Then: widget remains hidden, no error
+      expect(widget.isVisible()).toBe(false);
+    });
+  });
+
+  /* --- Debounce --- */
+
+  describe("Debounce", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("search executes after SEARCH_DEBOUNCE_MS delay (TC-FW-N-21)", () => {
+      // Given: widget is visible with commits
+      const commits = [makeCommit({ hash: "aaa1111100000000", message: "fix bug" })];
+      setupCommitsAndDom(commits, callbacks);
+      widget.show(false);
+
+      const inputElem = document.getElementById("findInput") as HTMLInputElement;
+      inputElem.value = "fix";
+
+      // When: keyup event is dispatched
+      inputElem.dispatchEvent(new KeyboardEvent("keyup", { key: "f" }));
+
+      // Then: search not executed immediately
+      expect(getPositionText()).toBe("No Results");
+
+      // When: SEARCH_DEBOUNCE_MS elapses
+      vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS);
+
+      // Then: search is executed
+      expect(getPositionText()).toBe("1 of 1");
+    });
+
+    it("rapid input resets debounce timer (TC-FW-B-08)", () => {
+      // Given: widget is visible with commits
+      const commits = [
+        makeCommit({ hash: "aaa1111100000000", message: "fix bug" }),
+        makeCommit({ hash: "bbb2222200000000", message: "add feature" })
+      ];
+      setupCommitsAndDom(commits, callbacks);
+      widget.show(false);
+
+      const inputElem = document.getElementById("findInput") as HTMLInputElement;
+
+      // When: first input "fi" then after 100ms change to "add"
+      inputElem.value = "fi";
+      inputElem.dispatchEvent(new KeyboardEvent("keyup", { key: "i" }));
+      vi.advanceTimersByTime(100);
+
+      inputElem.value = "add";
+      inputElem.dispatchEvent(new KeyboardEvent("keyup", { key: "d" }));
+
+      // Then: after another 100ms (200ms total), first search is not executed
+      vi.advanceTimersByTime(100);
+      expect(getPositionText()).toBe("No Results");
+
+      // When: full SEARCH_DEBOUNCE_MS after second input
+      vi.advanceTimersByTime(100);
+
+      // Then: search executes with "add", not "fi"
+      expect(getPositionText()).toBe("1 of 1");
+    });
+  });
+});

--- a/tests/web/graph.test.ts
+++ b/tests/web/graph.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { GitCommitNode } from "../../src/types";
+
+/* ------------------------------------------------------------------ */
+/* Mock DOM                                                           */
+/* ------------------------------------------------------------------ */
+
+interface MockElement {
+  tagName: string;
+  attributes: Map<string, string>;
+  children: MockElement[];
+  setAttribute(name: string, value: string): void;
+  getAttribute(name: string): string | null;
+  appendChild(child: unknown): void;
+  removeChild(child: unknown): void;
+}
+
+function createMockElement(tagName: string): MockElement {
+  const attributes = new Map<string, string>();
+  const children: MockElement[] = [];
+  return {
+    tagName,
+    attributes,
+    children,
+    setAttribute(name: string, value: string) {
+      attributes.set(name, value);
+    },
+    getAttribute(name: string) {
+      return attributes.get(name) ?? null;
+    },
+    appendChild(child: unknown) {
+      children.push(child as MockElement);
+    },
+    removeChild(child: unknown) {
+      const idx = children.indexOf(child as MockElement);
+      if (idx >= 0) children.splice(idx, 1);
+    }
+  };
+}
+
+let allCreatedElements: MockElement[] = [];
+let containerElement: MockElement;
+
+vi.stubGlobal("document", {
+  createElementNS: vi.fn((_ns: string, localName: string) => {
+    const el = createMockElement(localName);
+    allCreatedElements.push(el);
+    return el;
+  }),
+  getElementById: vi.fn(() => containerElement)
+});
+
+import { Graph } from "../../web/graph";
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+const DEFAULT_CONFIG: Config = {
+  autoCenterCommitDetailsView: false,
+  fetchAvatars: false,
+  graphColours: ["#0085d9", "#d9534f", "#428bca", "#5cb85c"],
+  graphStyle: "rounded",
+  grid: { x: 16, y: 24, offsetX: 8, offsetY: 12, expandY: 160 },
+  initialLoadCommits: 300,
+  loadMoreCommits: 100,
+  showCurrentBranchByDefault: false
+};
+
+function makeCommit(
+  hash: string,
+  parentHashes: string[],
+  stash: GitCommitNode["stash"]
+): GitCommitNode {
+  return {
+    hash,
+    parentHashes,
+    author: "Test Author",
+    email: "test@example.com",
+    date: 1000000,
+    message: "test commit",
+    refs: [],
+    stash
+  };
+}
+
+function getCircleElements(): MockElement[] {
+  return allCreatedElements.filter((e) => e.tagName === "circle");
+}
+
+/* ------------------------------------------------------------------ */
+/* Tests                                                              */
+/* ------------------------------------------------------------------ */
+
+describe("Graph stash vertex drawing", () => {
+  beforeEach(() => {
+    allCreatedElements = [];
+    containerElement = createMockElement("div");
+    vi.clearAllMocks();
+  });
+
+  it("draws double circle (outer + inner ring) for stash vertex (TC-SR-N-06)", () => {
+    // Given: a commit node with stash !== null
+    const graph = new Graph("testGraph", DEFAULT_CONFIG);
+    const stashCommit = makeCommit("abc123def456", [], {
+      selector: "stash@{0}",
+      baseHash: "000111",
+      untrackedFilesHash: null
+    });
+    graph.loadCommits([stashCommit], null, { abc123def456: 0 });
+
+    // When: graph is rendered
+    allCreatedElements = [];
+    graph.render(null);
+
+    // Then: two circles are drawn — outer (stashOuter) and inner (stashInner)
+    const circles = getCircleElements();
+    expect(circles.length).toBe(2);
+
+    const outerCircle = circles.find((c) => c.attributes.get("class") === "stashOuter");
+    const innerCircle = circles.find((c) => c.attributes.get("class") === "stashInner");
+
+    expect(outerCircle).toBeDefined();
+    expect(innerCircle).toBeDefined();
+
+    // Outer circle: filled, r=4
+    expect(outerCircle!.attributes.get("r")).toBe("4");
+    expect(outerCircle!.attributes.has("fill")).toBe(true);
+
+    // Inner circle: ring (stroke), r=2
+    expect(innerCircle!.attributes.get("r")).toBe("2");
+    expect(innerCircle!.attributes.has("stroke")).toBe(true);
+  });
+
+  it("draws single circle for non-stash vertex (TC-SR-N-07)", () => {
+    // Given: a commit node with stash === null (regular commit)
+    const graph = new Graph("testGraph", DEFAULT_CONFIG);
+    const regularCommit = makeCommit("abc123def456", [], null);
+    graph.loadCommits([regularCommit], null, { abc123def456: 0 });
+
+    // When: graph is rendered
+    allCreatedElements = [];
+    graph.render(null);
+
+    // Then: exactly one circle is drawn (no stashOuter/stashInner)
+    const circles = getCircleElements();
+    expect(circles.length).toBe(1);
+
+    const stashOuter = circles.filter((c) => c.attributes.get("class") === "stashOuter");
+    const stashInner = circles.filter((c) => c.attributes.get("class") === "stashInner");
+    expect(stashOuter.length).toBe(0);
+    expect(stashInner.length).toBe(0);
+
+    // The single circle has fill (not stroke-only ring)
+    expect(circles[0].attributes.has("fill")).toBe(true);
+  });
+});

--- a/tests/web/main.test.ts
+++ b/tests/web/main.test.ts
@@ -1,0 +1,1528 @@
+// @vitest-environment jsdom
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { GitCommitDetails, GitCommitNode, GitCommitStash } from "../../src/types";
+import { UNCOMMITTED_CHANGES_HASH } from "../../src/types";
+
+/* ------------------------------------------------------------------ */
+/* Hoisted mocks (shared references for mock factories + assertions)  */
+/* ------------------------------------------------------------------ */
+
+const { mockFindWidgetInstance } = vi.hoisted(() => ({
+  mockFindWidgetInstance: {
+    show: vi.fn(),
+    close: vi.fn(),
+    isVisible: vi.fn(() => false),
+    refresh: vi.fn(),
+    setInputEnabled: vi.fn(),
+    getState: vi.fn(() => ({
+      text: "",
+      currentHash: null,
+      visible: false,
+      caseSensitive: false,
+      regex: false
+    })),
+    restoreState: vi.fn(),
+    getCurrentHash: vi.fn(() => null)
+  }
+}));
+
+/* ------------------------------------------------------------------ */
+/* Mock: dialogs module (prevents document.getElementById side effect) */
+/* ------------------------------------------------------------------ */
+
+vi.mock("../../web/dialogs", () => ({
+  showCheckboxDialog: vi.fn(),
+  showConfirmationDialog: vi.fn(),
+  showRefInputDialog: vi.fn(),
+  showFormDialog: vi.fn(),
+  showSelectDialog: vi.fn(),
+  showErrorDialog: vi.fn(),
+  showActionRunningDialog: vi.fn(),
+  hideDialog: vi.fn(),
+  isDialogActive: vi.fn(() => false)
+}));
+
+/* ------------------------------------------------------------------ */
+/* Mock: findWidget module                                            */
+/* ------------------------------------------------------------------ */
+
+vi.mock("../../web/findWidget", () => ({
+  FindWidget: vi.fn(function () {
+    return mockFindWidgetInstance;
+  })
+}));
+
+/* ------------------------------------------------------------------ */
+/* Mock: graph module                                                 */
+/* ------------------------------------------------------------------ */
+
+vi.mock("../../web/graph", () => ({
+  Graph: vi.fn(function () {
+    return {
+      loadCommits: vi.fn(),
+      render: vi.fn(),
+      clear: vi.fn(),
+      getVertexColour: vi.fn(() => 0),
+      getWidth: vi.fn(() => 100),
+      getHeight: vi.fn(() => 500),
+      limitMaxWidth: vi.fn()
+    };
+  })
+}));
+
+/* ------------------------------------------------------------------ */
+/* Mock: dropdown module                                              */
+/* ------------------------------------------------------------------ */
+
+vi.mock("../../web/dropdown", () => ({
+  Dropdown: vi.fn(function () {
+    return {
+      setOptions: vi.fn(),
+      refresh: vi.fn()
+    };
+  })
+}));
+
+/* ------------------------------------------------------------------ */
+/* Mock: contextMenu module                                           */
+/* ------------------------------------------------------------------ */
+
+vi.mock("../../web/contextMenu", () => ({
+  hideContextMenu: vi.fn(),
+  hideContextMenuListener: vi.fn(),
+  isContextMenuActive: vi.fn(() => false),
+  showContextMenu: vi.fn()
+}));
+
+/* ------------------------------------------------------------------ */
+/* Mock: branchLabels module                                          */
+/* ------------------------------------------------------------------ */
+
+vi.mock("../../web/branchLabels", () => ({
+  getBranchLabels: vi.fn(() => ({ heads: [], remotes: [], tags: [] }))
+}));
+
+/* ------------------------------------------------------------------ */
+/* Mock: dates module                                                 */
+/* ------------------------------------------------------------------ */
+
+vi.mock("../../web/dates", () => ({
+  getCommitDate: vi.fn(() => ({ title: "2026-01-01", value: "2026-01-01" }))
+}));
+
+/* ------------------------------------------------------------------ */
+/* Mock: fileTree module                                              */
+/* ------------------------------------------------------------------ */
+
+vi.mock("../../web/fileTree", () => ({
+  alterGitFileTree: vi.fn(),
+  generateGitFileTree: vi.fn(() => ({
+    type: "folder",
+    name: "",
+    folderPath: "",
+    contents: {},
+    open: true
+  })),
+  generateGitFileTreeHtml: vi.fn(() => "<table></table>")
+}));
+
+import {
+  showCheckboxDialog,
+  showConfirmationDialog,
+  showErrorDialog,
+  showFormDialog,
+  showRefInputDialog,
+  showSelectDialog
+} from "../../web/dialogs";
+import { generateGitFileTreeHtml } from "../../web/fileTree";
+import { buildStashContextMenuItems } from "../../web/stashMenu";
+import { buildUncommittedContextMenuItems } from "../../web/uncommittedMenu";
+import {
+  buildCommitRowAttributes,
+  buildStashSelectorDisplay,
+  escapeHtml,
+  refreshGraphOrDisplayError,
+  sendMessage,
+  vscode
+} from "../../web/utils";
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function makeStash(overrides: Partial<GitCommitStash> = {}): GitCommitStash {
+  return {
+    selector: "stash@{0}",
+    baseHash: "abc123",
+    untrackedFilesHash: null,
+    ...overrides
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* Tests: Stash row rendering (Task 3.4)                              */
+/* ------------------------------------------------------------------ */
+
+describe("buildCommitRowAttributes", () => {
+  it("includes 'commit' and 'stash' CSS classes for stash commit (TC-SR-N-01)", () => {
+    // Given: a commit node with stash !== null
+    const hash = "abc123def456";
+    const stash = makeStash();
+
+    // When: row attributes are generated
+    const result = buildCommitRowAttributes(hash, stash);
+
+    // Then: CSS classes contain both "commit" and "stash"
+    expect(result).toContain('class="commit stash"');
+  });
+
+  it("includes data-hash attribute with commit hash for stash commit (TC-SR-N-04)", () => {
+    // Given: a stash commit with a specific hash
+    const hash = "abc123def456";
+    const stash = makeStash();
+
+    // When: row attributes are generated
+    const result = buildCommitRowAttributes(hash, stash);
+
+    // Then: data-hash attribute contains the commit hash
+    expect(result).toContain(`data-hash="${hash}"`);
+  });
+
+  it("does not include 'stash' CSS class for non-stash commit (TC-SR-N-05)", () => {
+    // Given: a commit node with stash === null (regular commit)
+    const hash = "abc123def456";
+
+    // When: row attributes are generated
+    const result = buildCommitRowAttributes(hash, null);
+
+    // Then: CSS class contains "commit" but NOT "stash"
+    expect(result).toContain('class="commit"');
+    expect(result).not.toContain("stash");
+  });
+
+  it("returns unsavedChanges class with data-hash for uncommitted changes hash", () => {
+    // Given: the uncommitted changes hash
+    // When: row attributes are generated
+    const result = buildCommitRowAttributes(UNCOMMITTED_CHANGES_HASH, null);
+
+    // Then: class is "unsavedChanges" with data-hash="*"
+    expect(result).toContain('class="unsavedChanges"');
+    expect(result).toContain(`data-hash="${UNCOMMITTED_CHANGES_HASH}"`);
+  });
+});
+
+describe("buildStashSelectorDisplay", () => {
+  it("extracts @{0} from stash@{0} (TC-SR-N-02)", () => {
+    // Given: selector is "stash@{0}"
+    const selector = "stash@{0}";
+
+    // When: selector display is generated
+    const display = buildStashSelectorDisplay(selector);
+
+    // Then: "@{0}" is returned (stash prefix removed)
+    expect(display).toBe("@{0}");
+  });
+
+  it("extracts @{12} from stash@{12} for multi-digit index (TC-SR-N-03)", () => {
+    // Given: selector is "stash@{12}" (multi-digit index)
+    const selector = "stash@{12}";
+
+    // When: selector display is generated
+    const display = buildStashSelectorDisplay(selector);
+
+    // Then: "@{12}" is returned
+    expect(display).toBe("@{12}");
+  });
+
+  it("produces HTML-safe output when combined with escapeHtml", () => {
+    // Given: selector display with characters that escapeHtml processes
+    const selector = "stash@{0}";
+    const display = escapeHtml(buildStashSelectorDisplay(selector));
+
+    // Then: output is safe and matches expected display
+    expect(display).toBe("@{0}");
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* Tests: Stash context menu (Task 4.4)                               */
+/* ------------------------------------------------------------------ */
+
+const MOCK_REPO = "/path/to/repo";
+const MOCK_HASH = "abc123def456";
+const MOCK_SELECTOR = "stash@{0}";
+const MOCK_SOURCE_ELEM = {} as HTMLElement;
+
+describe("buildStashContextMenuItems", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(vscode.postMessage).mockClear();
+  });
+
+  it("returns 7 items (4 actions + separator + 2 copy) for stash context menu (TC-SC-N-01)", () => {
+    // Given: stash !== null commit row
+    // When: stash context menu items are built
+    const items = buildStashContextMenuItems(MOCK_REPO, MOCK_HASH, MOCK_SELECTOR, MOCK_SOURCE_ELEM);
+
+    // Then: 7 items including separator (null)
+    expect(items).toHaveLength(7);
+    expect(items[0]).not.toBeNull();
+    expect(items[1]).not.toBeNull();
+    expect(items[2]).not.toBeNull();
+    expect(items[3]).not.toBeNull();
+    expect(items[4]).toBeNull();
+    expect(items[5]).not.toBeNull();
+    expect(items[6]).not.toBeNull();
+
+    // Verify menu item titles
+    expect(items[0]!.title).toContain("Apply Stash");
+    expect(items[1]!.title).toContain("Create Branch from Stash");
+    expect(items[2]!.title).toContain("Pop Stash");
+    expect(items[3]!.title).toContain("Drop Stash");
+    expect(items[5]!.title).toBe("Copy Stash Name to Clipboard");
+    expect(items[6]!.title).toBe("Copy Stash Hash to Clipboard");
+  });
+
+  it("shows checkbox dialog with 'Reinstate Index' default false when Apply is clicked (TC-SC-N-02)", () => {
+    // Given: stash context menu items
+    const items = buildStashContextMenuItems(MOCK_REPO, MOCK_HASH, MOCK_SELECTOR, MOCK_SOURCE_ELEM);
+
+    // When: "Apply Stash..." is clicked
+    items[0]!.onClick();
+
+    // Then: showCheckboxDialog is called with "Reinstate Index" and default false
+    expect(showCheckboxDialog).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(showCheckboxDialog).mock.calls[0];
+    expect(call[1]).toBe("Reinstate Index");
+    expect(call[2]).toBe(false);
+  });
+
+  it("sends applyStash with reinstateIndex: true when confirmed with Reinstate Index ON (TC-SC-N-03)", () => {
+    // Given: stash context menu items
+    const items = buildStashContextMenuItems(MOCK_REPO, MOCK_HASH, MOCK_SELECTOR, MOCK_SOURCE_ELEM);
+    items[0]!.onClick();
+
+    // When: dialog is confirmed with reinstateIndex = true
+    const onConfirm = vi.mocked(showCheckboxDialog).mock.calls[0][4];
+    onConfirm(true);
+
+    // Then: applyStash message is sent with reinstateIndex: true
+    expect(vscode.postMessage).toHaveBeenCalledWith({
+      command: "applyStash",
+      repo: MOCK_REPO,
+      selector: MOCK_SELECTOR,
+      reinstateIndex: true
+    });
+  });
+
+  it("sends applyStash with reinstateIndex: false when confirmed with Reinstate Index OFF (TC-SC-N-04)", () => {
+    // Given: stash context menu items
+    const items = buildStashContextMenuItems(MOCK_REPO, MOCK_HASH, MOCK_SELECTOR, MOCK_SOURCE_ELEM);
+    items[0]!.onClick();
+
+    // When: dialog is confirmed with reinstateIndex = false
+    const onConfirm = vi.mocked(showCheckboxDialog).mock.calls[0][4];
+    onConfirm(false);
+
+    // Then: applyStash message is sent with reinstateIndex: false
+    expect(vscode.postMessage).toHaveBeenCalledWith({
+      command: "applyStash",
+      repo: MOCK_REPO,
+      selector: MOCK_SELECTOR,
+      reinstateIndex: false
+    });
+  });
+
+  it("sends popStash message when Pop is confirmed (TC-SC-N-05)", () => {
+    // Given: stash context menu items
+    const items = buildStashContextMenuItems(MOCK_REPO, MOCK_HASH, MOCK_SELECTOR, MOCK_SOURCE_ELEM);
+
+    // When: "Pop Stash..." is clicked and confirmed
+    items[2]!.onClick();
+    expect(showCheckboxDialog).toHaveBeenCalledTimes(1);
+    const onConfirm = vi.mocked(showCheckboxDialog).mock.calls[0][4];
+    onConfirm(false);
+
+    // Then: popStash message is sent
+    expect(vscode.postMessage).toHaveBeenCalledWith({
+      command: "popStash",
+      repo: MOCK_REPO,
+      selector: MOCK_SELECTOR,
+      reinstateIndex: false
+    });
+  });
+
+  it("shows confirmation dialog when Drop is clicked (TC-SC-N-06)", () => {
+    // Given: stash context menu items
+    const items = buildStashContextMenuItems(MOCK_REPO, MOCK_HASH, MOCK_SELECTOR, MOCK_SOURCE_ELEM);
+
+    // When: "Drop Stash..." is clicked
+    items[3]!.onClick();
+
+    // Then: showConfirmationDialog is called
+    expect(showConfirmationDialog).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends dropStash message when Drop is confirmed (TC-SC-N-07)", () => {
+    // Given: stash context menu items
+    const items = buildStashContextMenuItems(MOCK_REPO, MOCK_HASH, MOCK_SELECTOR, MOCK_SOURCE_ELEM);
+    items[3]!.onClick();
+
+    // When: confirmation dialog is confirmed
+    const onConfirm = vi.mocked(showConfirmationDialog).mock.calls[0][1];
+    onConfirm();
+
+    // Then: dropStash message is sent
+    expect(vscode.postMessage).toHaveBeenCalledWith({
+      command: "dropStash",
+      repo: MOCK_REPO,
+      selector: MOCK_SELECTOR
+    });
+  });
+
+  it("shows ref input dialog when Create Branch is clicked (TC-SC-N-08)", () => {
+    // Given: stash context menu items
+    const items = buildStashContextMenuItems(MOCK_REPO, MOCK_HASH, MOCK_SELECTOR, MOCK_SOURCE_ELEM);
+
+    // When: "Create Branch from Stash..." is clicked
+    items[1]!.onClick();
+
+    // Then: showRefInputDialog is called
+    expect(showRefInputDialog).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends branchFromStash message when Branch dialog is confirmed (TC-SC-N-09)", () => {
+    // Given: stash context menu items
+    const items = buildStashContextMenuItems(MOCK_REPO, MOCK_HASH, MOCK_SELECTOR, MOCK_SOURCE_ELEM);
+    items[1]!.onClick();
+
+    // When: branch name is entered and confirmed
+    const onConfirm = vi.mocked(showRefInputDialog).mock.calls[0][3];
+    onConfirm("new-branch-from-stash");
+
+    // Then: branchFromStash message is sent
+    expect(vscode.postMessage).toHaveBeenCalledWith({
+      command: "branchFromStash",
+      repo: MOCK_REPO,
+      branchName: "new-branch-from-stash",
+      selector: MOCK_SELECTOR
+    });
+  });
+
+  it("sends copyToClipboard with Stash Name when Copy Name is clicked (TC-SC-N-10)", () => {
+    // Given: stash context menu items
+    const items = buildStashContextMenuItems(MOCK_REPO, MOCK_HASH, MOCK_SELECTOR, MOCK_SOURCE_ELEM);
+
+    // When: "Copy Stash Name to Clipboard" is clicked
+    items[5]!.onClick();
+
+    // Then: copyToClipboard message is sent with type "Stash Name"
+    expect(vscode.postMessage).toHaveBeenCalledWith({
+      command: "copyToClipboard",
+      type: "Stash Name",
+      data: MOCK_SELECTOR
+    });
+  });
+
+  it("sends copyToClipboard with Stash Hash when Copy Hash is clicked (TC-SC-N-11)", () => {
+    // Given: stash context menu items
+    const items = buildStashContextMenuItems(MOCK_REPO, MOCK_HASH, MOCK_SELECTOR, MOCK_SOURCE_ELEM);
+
+    // When: "Copy Stash Hash to Clipboard" is clicked
+    items[6]!.onClick();
+
+    // Then: copyToClipboard message is sent with type "Stash Hash"
+    expect(vscode.postMessage).toHaveBeenCalledWith({
+      command: "copyToClipboard",
+      type: "Stash Hash",
+      data: MOCK_HASH
+    });
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* Tests: Uncommitted Changes context menu (Task 5.4)                 */
+/* ------------------------------------------------------------------ */
+
+describe("buildUncommittedContextMenuItems", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(vscode.postMessage).mockClear();
+  });
+
+  it("returns 3 items (Stash, Reset, Clean) for uncommitted context menu (TC-UC-N-01)", () => {
+    // Given: Uncommitted Changes row
+    // When: uncommitted context menu items are built
+    const items = buildUncommittedContextMenuItems(MOCK_REPO, MOCK_SOURCE_ELEM);
+
+    // Then: 3 menu items
+    expect(items).toHaveLength(3);
+    expect(items[0]).not.toBeNull();
+    expect(items[1]).not.toBeNull();
+    expect(items[2]).not.toBeNull();
+
+    // Verify menu item titles
+    expect(items[0]!.title).toContain("Stash uncommitted changes");
+    expect(items[1]!.title).toContain("Reset uncommitted changes");
+    expect(items[2]!.title).toContain("Clean untracked files");
+  });
+
+  it("shows form dialog with message input and Include Untracked checkbox when Stash is clicked (TC-UC-N-02)", () => {
+    // Given: uncommitted context menu items
+    const items = buildUncommittedContextMenuItems(MOCK_REPO, MOCK_SOURCE_ELEM);
+
+    // When: "Stash uncommitted changes..." is clicked
+    items[0]!.onClick();
+
+    // Then: showFormDialog is called with text input and checkbox input
+    expect(showFormDialog).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(showFormDialog).mock.calls[0];
+    expect(call[0]).toContain("Stash uncommitted changes");
+    const inputs = call[1];
+    expect(inputs).toHaveLength(2);
+    expect(inputs[0].type).toBe("text");
+    expect(inputs[0].name).toBe("Message: ");
+    expect(inputs[1].type).toBe("checkbox");
+    expect(inputs[1].name).toBe("Include Untracked");
+  });
+
+  it("sends pushStash with message and includeUntracked: true when Stash confirmed with options (TC-UC-N-03)", () => {
+    // Given: uncommitted context menu items
+    const items = buildUncommittedContextMenuItems(MOCK_REPO, MOCK_SOURCE_ELEM);
+    items[0]!.onClick();
+
+    // When: form dialog is confirmed with message and Include Untracked ON
+    const onConfirm = vi.mocked(showFormDialog).mock.calls[0][3];
+    onConfirm(["WIP: work in progress", "checked"]);
+
+    // Then: pushStash message is sent with message and includeUntracked: true
+    expect(vscode.postMessage).toHaveBeenCalledWith({
+      command: "pushStash",
+      repo: MOCK_REPO,
+      message: "WIP: work in progress",
+      includeUntracked: true
+    });
+  });
+
+  it("sends pushStash with empty message and includeUntracked: false when Stash confirmed with defaults (TC-UC-N-04)", () => {
+    // Given: uncommitted context menu items
+    const items = buildUncommittedContextMenuItems(MOCK_REPO, MOCK_SOURCE_ELEM);
+    items[0]!.onClick();
+
+    // When: form dialog is confirmed with empty message and Include Untracked OFF
+    const onConfirm = vi.mocked(showFormDialog).mock.calls[0][3];
+    onConfirm(["", "unchecked"]);
+
+    // Then: pushStash message is sent with empty message and includeUntracked: false
+    expect(vscode.postMessage).toHaveBeenCalledWith({
+      command: "pushStash",
+      repo: MOCK_REPO,
+      message: "",
+      includeUntracked: false
+    });
+  });
+
+  it("shows select dialog with Mixed and Hard options when Reset is clicked (TC-UC-N-05)", () => {
+    // Given: uncommitted context menu items
+    const items = buildUncommittedContextMenuItems(MOCK_REPO, MOCK_SOURCE_ELEM);
+
+    // When: "Reset uncommitted changes..." is clicked
+    items[1]!.onClick();
+
+    // Then: showSelectDialog is called with Mixed and Hard options
+    expect(showSelectDialog).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(showSelectDialog).mock.calls[0];
+    expect(call[0]).toContain("reset uncommitted changes");
+    expect(call[1]).toBe("mixed");
+    const options = call[2];
+    expect(options).toHaveLength(2);
+    expect(options[0].value).toBe("mixed");
+    expect(options[1].value).toBe("hard");
+  });
+
+  it("sends resetUncommitted with mode: mixed after select and confirmation (TC-UC-N-06)", () => {
+    // Given: uncommitted context menu items
+    const items = buildUncommittedContextMenuItems(MOCK_REPO, MOCK_SOURCE_ELEM);
+    items[1]!.onClick();
+
+    // When: "Mixed" is selected in the select dialog
+    const onSelect = vi.mocked(showSelectDialog).mock.calls[0][4];
+    onSelect("mixed");
+
+    // Then: confirmation dialog is shown
+    expect(showConfirmationDialog).toHaveBeenCalledTimes(1);
+    const confirmCall = vi.mocked(showConfirmationDialog).mock.calls[0];
+    expect(confirmCall[0]).toContain("mixed");
+
+    // When: confirmation dialog is confirmed
+    confirmCall[1]();
+
+    // Then: resetUncommitted message is sent with mode: "mixed"
+    expect(vscode.postMessage).toHaveBeenCalledWith({
+      command: "resetUncommitted",
+      repo: MOCK_REPO,
+      mode: "mixed"
+    });
+  });
+
+  it("sends resetUncommitted with mode: hard after select and confirmation (TC-UC-N-07)", () => {
+    // Given: uncommitted context menu items
+    const items = buildUncommittedContextMenuItems(MOCK_REPO, MOCK_SOURCE_ELEM);
+    items[1]!.onClick();
+
+    // When: "Hard" is selected in the select dialog
+    const onSelect = vi.mocked(showSelectDialog).mock.calls[0][4];
+    onSelect("hard");
+
+    // Then: confirmation dialog is shown with hard mode warning
+    expect(showConfirmationDialog).toHaveBeenCalledTimes(1);
+    const confirmCall = vi.mocked(showConfirmationDialog).mock.calls[0];
+    expect(confirmCall[0]).toContain("hard");
+    expect(confirmCall[0]).toContain("cannot be undone");
+
+    // When: confirmation dialog is confirmed
+    confirmCall[1]();
+
+    // Then: resetUncommitted message is sent with mode: "hard"
+    expect(vscode.postMessage).toHaveBeenCalledWith({
+      command: "resetUncommitted",
+      repo: MOCK_REPO,
+      mode: "hard"
+    });
+  });
+
+  it("shows checkbox dialog with 'Clean untracked directories' default false when Clean is clicked (TC-UC-N-08)", () => {
+    // Given: uncommitted context menu items
+    const items = buildUncommittedContextMenuItems(MOCK_REPO, MOCK_SOURCE_ELEM);
+
+    // When: "Clean untracked files..." is clicked
+    items[2]!.onClick();
+
+    // Then: showCheckboxDialog is called with "Clean untracked directories" and default false
+    expect(showCheckboxDialog).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(showCheckboxDialog).mock.calls[0];
+    expect(call[0]).toContain("clean untracked files");
+    expect(call[1]).toBe("Clean untracked directories");
+    expect(call[2]).toBe(false);
+  });
+
+  it("sends cleanUntrackedFiles with directories: true when Clean confirmed with option ON (TC-UC-N-09)", () => {
+    // Given: uncommitted context menu items
+    const items = buildUncommittedContextMenuItems(MOCK_REPO, MOCK_SOURCE_ELEM);
+    items[2]!.onClick();
+
+    // When: checkbox dialog is confirmed with directories = true
+    const onConfirm = vi.mocked(showCheckboxDialog).mock.calls[0][4];
+    onConfirm(true);
+
+    // Then: cleanUntrackedFiles message is sent with directories: true
+    expect(vscode.postMessage).toHaveBeenCalledWith({
+      command: "cleanUntrackedFiles",
+      repo: MOCK_REPO,
+      directories: true
+    });
+  });
+
+  it("sends cleanUntrackedFiles with directories: false when Clean confirmed with option OFF (TC-UC-N-10)", () => {
+    // Given: uncommitted context menu items
+    const items = buildUncommittedContextMenuItems(MOCK_REPO, MOCK_SOURCE_ELEM);
+    items[2]!.onClick();
+
+    // When: checkbox dialog is confirmed with directories = false
+    const onConfirm = vi.mocked(showCheckboxDialog).mock.calls[0][4];
+    onConfirm(false);
+
+    // Then: cleanUntrackedFiles message is sent with directories: false
+    expect(vscode.postMessage).toHaveBeenCalledWith({
+      command: "cleanUntrackedFiles",
+      repo: MOCK_REPO,
+      directories: false
+    });
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* Tests: Fetch button and response handler (Task 6.2)                */
+/* ------------------------------------------------------------------ */
+
+describe("fetch button message", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(vscode.postMessage).mockClear();
+  });
+
+  it("sends fetch message with correct format including repo (TC-FT-N-04)", () => {
+    // Given: fetch button is clicked (simulated via sendMessage)
+    const repo = "/test/repo";
+
+    // When: sendMessage is called with fetch command (as the button handler does)
+    sendMessage({ command: "fetch", repo });
+
+    // Then: postMessage is called with { command: "fetch", repo }
+    expect(vscode.postMessage).toHaveBeenCalledTimes(1);
+    expect(vscode.postMessage).toHaveBeenCalledWith({
+      command: "fetch",
+      repo
+    });
+  });
+});
+
+describe("refreshGraphOrDisplayError", () => {
+  let mockRefresh: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRefresh = vi.fn();
+  });
+
+  it("calls onRefresh when status is null (TC-FT-N-05)", () => {
+    // Given: fetch response with status === null (success)
+    const status = null;
+    const errorMessage = "Unable to Fetch";
+
+    // When: refreshGraphOrDisplayError is called
+    refreshGraphOrDisplayError(status, errorMessage, mockRefresh, vi.mocked(showErrorDialog));
+
+    // Then: onRefresh (graph refresh) is called, error dialog is NOT shown
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+    expect(showErrorDialog).not.toHaveBeenCalled();
+  });
+
+  it("calls showErrorDialog when status is an error message (TC-FT-A-02)", () => {
+    // Given: fetch response with status === "error message" (failure)
+    const status = "fatal: Could not resolve host";
+    const errorMessage = "Unable to Fetch";
+
+    // When: refreshGraphOrDisplayError is called
+    refreshGraphOrDisplayError(status, errorMessage, mockRefresh, vi.mocked(showErrorDialog));
+
+    // Then: showErrorDialog is called with error details, onRefresh is NOT called
+    expect(showErrorDialog).toHaveBeenCalledTimes(1);
+    expect(showErrorDialog).toHaveBeenCalledWith(errorMessage, status, null);
+    expect(mockRefresh).not.toHaveBeenCalled();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* Tests: Frontend integration — comparison mode & FindWidget (4.3)   */
+/* ------------------------------------------------------------------ */
+
+const COMMIT_HASH_1 = "aaa111aaa111aaa1";
+const COMMIT_HASH_2 = "bbb222bbb222bbb2";
+const COMMIT_HASH_3 = "ccc333ccc333ccc3";
+const DUMMY_HASH = "ddd444ddd444ddd4";
+const TEST_REPO = "/test/repo";
+
+const MOCK_COMMITS: GitCommitNode[] = [
+  {
+    hash: COMMIT_HASH_1,
+    parentHashes: [],
+    author: "Alice",
+    email: "alice@test.com",
+    date: 1700000000,
+    message: "First commit",
+    refs: [],
+    stash: null
+  },
+  {
+    hash: COMMIT_HASH_2,
+    parentHashes: [COMMIT_HASH_1],
+    author: "Bob",
+    email: "bob@test.com",
+    date: 1700001000,
+    message: "Second commit",
+    refs: [],
+    stash: null
+  },
+  {
+    hash: COMMIT_HASH_3,
+    parentHashes: [COMMIT_HASH_2],
+    author: "Carol",
+    email: "carol@test.com",
+    date: 1700002000,
+    message: "Third commit",
+    refs: [],
+    stash: null
+  }
+];
+
+const MOCK_PREV_STATE: WebViewState = {
+  gitRepos: { [TEST_REPO]: { columnWidths: null } },
+  gitBranches: ["main"],
+  gitBranchHead: "main",
+  commits: MOCK_COMMITS,
+  commitHead: COMMIT_HASH_1,
+  avatars: {},
+  currentBranch: "",
+  currentRepo: TEST_REPO,
+  moreCommitsAvailable: false,
+  maxCommits: 300,
+  showRemoteBranches: true,
+  expandedCommit: null,
+  findWidgetState: {
+    text: "test-search",
+    currentHash: null,
+    visible: true,
+    caseSensitive: false,
+    regex: false
+  }
+};
+
+function setupTestDOM(): void {
+  document.body.innerHTML = [
+    '<div id="scrollContainer">',
+    '  <div id="commitGraph"></div>',
+    '  <div id="commitTable"></div>',
+    "</div>",
+    '<div id="footer"></div>',
+    '<div id="repoControl"><div id="repoSelect"></div></div>',
+    '<div id="branchSelect"></div>',
+    '<input id="showRemoteBranchesCheckbox" type="checkbox" checked />',
+    '<div id="scrollShadow"></div>',
+    '<div id="refreshBtn"></div>',
+    '<div id="fetchBtn"></div>',
+    '<div id="currentBtn"></div>',
+    '<div id="searchBtn"></div>'
+  ].join("");
+}
+
+function setupViewState(): void {
+  (globalThis as Record<string, unknown>).viewState = {
+    repos: { [TEST_REPO]: { columnWidths: null } },
+    lastActiveRepo: TEST_REPO,
+    autoCenterCommitDetailsView: false,
+    dateFormat: "Date & Time",
+    fetchAvatars: false,
+    graphColours: ["#0085d9"],
+    graphStyle: "rounded",
+    initialLoadCommits: 300,
+    loadMoreCommits: 100,
+    showCurrentBranchByDefault: false
+  };
+}
+
+function dispatchMessage(data: Record<string, unknown>): void {
+  window.dispatchEvent(new MessageEvent("message", { data }));
+}
+
+function loadTestCommits(): void {
+  // Respond to the auto-request for branches
+  dispatchMessage({
+    command: "loadBranches",
+    branches: ["main"],
+    head: "main",
+    hard: false,
+    isRepo: true
+  });
+  // Respond to the auto-request for commits
+  dispatchMessage({
+    command: "loadCommits",
+    commits: MOCK_COMMITS,
+    head: COMMIT_HASH_1,
+    moreCommitsAvailable: false,
+    hard: false
+  });
+}
+
+function resetCommitState(): void {
+  // Load commits with dummy hashes to clear any expandedCommit
+  const dummyCommits: GitCommitNode[] = [
+    {
+      hash: DUMMY_HASH,
+      parentHashes: [],
+      author: "Dummy",
+      email: "dummy@test.com",
+      date: 1700000000,
+      message: "Dummy commit",
+      refs: [],
+      stash: null
+    }
+  ];
+  dispatchMessage({
+    command: "loadCommits",
+    commits: dummyCommits,
+    head: DUMMY_HASH,
+    moreCommitsAvailable: false,
+    hard: true
+  });
+  // Re-load the real commits
+  dispatchMessage({
+    command: "loadCommits",
+    commits: MOCK_COMMITS,
+    head: COMMIT_HASH_1,
+    moreCommitsAvailable: false,
+    hard: true
+  });
+  vi.clearAllMocks();
+}
+
+function clickCommit(hash: string, options?: { ctrlKey?: boolean; metaKey?: boolean }): void {
+  const row = document.querySelector(`.commit[data-hash="${hash}"]`);
+  if (row === null) throw new Error(`Commit row not found for hash: ${hash}`);
+  row.dispatchEvent(
+    new MouseEvent("click", {
+      bubbles: true,
+      ctrlKey: options?.ctrlKey ?? false,
+      metaKey: options?.metaKey ?? false
+    })
+  );
+}
+
+function clickUnsavedChanges(options?: { ctrlKey?: boolean; metaKey?: boolean }): void {
+  const row = document.querySelector(".unsavedChanges");
+  if (row === null) throw new Error("Unsaved changes row not found");
+  row.dispatchEvent(
+    new MouseEvent("click", {
+      bubbles: true,
+      ctrlKey: options?.ctrlKey ?? false,
+      metaKey: options?.metaKey ?? false
+    })
+  );
+}
+
+function makeCommitDetails(hash: string): GitCommitDetails {
+  return {
+    hash,
+    parents: [],
+    author: "",
+    email: "",
+    date: 0,
+    committer: "",
+    body: "",
+    fileChanges: []
+  };
+}
+
+function expandCommit(hash: string): void {
+  // Click the commit to request details
+  clickCommit(hash);
+  // Dispatch the commitDetails response
+  dispatchMessage({
+    command: "commitDetails",
+    commitDetails: makeCommitDetails(hash)
+  });
+  vi.clearAllMocks();
+}
+
+function expandCommitWithCompare(fromHash: string, toHash: string): void {
+  // Expand the base commit first
+  expandCommit(fromHash);
+  // Ctrl+click the compare target
+  clickCommit(toHash, { ctrlKey: true });
+  // Dispatch the compareCommits response with sample fileChanges
+  dispatchMessage({
+    command: "compareCommits",
+    fileChanges: [
+      { oldFilePath: "file.ts", newFilePath: "file.ts", type: "M", additions: 5, deletions: 2 }
+    ],
+    fromHash,
+    toHash
+  });
+  vi.clearAllMocks();
+}
+
+/* ------------------------------------------------------------------ */
+/* Integration: comparison mode & FindWidget (Task 4.3)               */
+/* ------------------------------------------------------------------ */
+
+describe("GitGraphView frontend integration", () => {
+  let restoreStateCaptured = false;
+
+  beforeAll(async () => {
+    setupTestDOM();
+    setupViewState();
+    // Set prevState with findWidgetState for TC-FI-N-11
+    vi.mocked(vscode.getState).mockReturnValueOnce(
+      MOCK_PREV_STATE as ReturnType<typeof vscode.getState>
+    );
+    await import("../../web/main");
+    // Respond to the auto-request from constructor
+    loadTestCommits();
+    // Check if restoreState was called during init (for TC-FI-N-11)
+    restoreStateCaptured = mockFindWidgetInstance.restoreState.mock.calls.length > 0;
+  });
+
+  beforeEach(() => {
+    resetCommitState();
+  });
+
+  /* ---------------------------------------------------------------- */
+  /* Comparison mode state transitions                                */
+  /* ---------------------------------------------------------------- */
+
+  describe("comparison mode state transitions", () => {
+    it("normal click sends commitDetails request (TC-FI-N-01)", () => {
+      // Given: no expanded commit, table is rendered with commits
+      // When: a commit row is clicked without modifier keys
+      clickCommit(COMMIT_HASH_1);
+
+      // Then: commitDetails message is sent with the clicked commit hash
+      expect(vscode.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: "commitDetails",
+          repo: TEST_REPO,
+          commitHash: COMMIT_HASH_1
+        })
+      );
+    });
+
+    it("Ctrl+click different commit enters compare mode (TC-FI-N-02)", () => {
+      // Given: commit 1 is expanded
+      expandCommit(COMMIT_HASH_1);
+
+      // When: a different commit is Ctrl+clicked
+      clickCommit(COMMIT_HASH_2, { ctrlKey: true });
+
+      // Then: compareCommits message is sent with older commit as fromHash
+      expect(vscode.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: "compareCommits",
+          repo: TEST_REPO,
+          fromHash: COMMIT_HASH_2,
+          toHash: COMMIT_HASH_1
+        })
+      );
+    });
+
+    it("Ctrl+click same compare target cancels comparison (TC-FI-N-03)", () => {
+      // Given: compare mode active between commit 1 and commit 2
+      expandCommitWithCompare(COMMIT_HASH_1, COMMIT_HASH_2);
+
+      // When: the same compare target (commit 2) is Ctrl+clicked again
+      clickCommit(COMMIT_HASH_2, { ctrlKey: true });
+
+      // Then: no compareCommits message is sent (comparison canceled)
+      const compareCalls = vi
+        .mocked(vscode.postMessage)
+        .mock.calls.filter(
+          (call) => (call[0] as Record<string, unknown>).command === "compareCommits"
+        );
+      expect(compareCalls).toHaveLength(0);
+
+      // Then: compareTarget class is removed from commit 2's row
+      const row2 = document.querySelector(`.commit[data-hash="${COMMIT_HASH_2}"]`);
+      expect(row2).not.toBeNull();
+      expect(row2!.classList.contains("compareTarget")).toBe(false);
+    });
+
+    it("Ctrl+click different commit changes comparison target (TC-FI-N-04)", () => {
+      // Given: compare mode active between commit 1 and commit 2
+      expandCommitWithCompare(COMMIT_HASH_1, COMMIT_HASH_2);
+
+      // When: a different commit (commit 3) is Ctrl+clicked
+      clickCommit(COMMIT_HASH_3, { ctrlKey: true });
+
+      // Then: compareCommits message is sent with older commit as fromHash
+      expect(vscode.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: "compareCommits",
+          fromHash: COMMIT_HASH_3,
+          toHash: COMMIT_HASH_1
+        })
+      );
+
+      // Then: commit 3's row has compareTarget class
+      const row3 = document.querySelector(`.commit[data-hash="${COMMIT_HASH_3}"]`);
+      expect(row3).not.toBeNull();
+      expect(row3!.classList.contains("compareTarget")).toBe(true);
+
+      // Then: commit 2's row does NOT have compareTarget class
+      const row2 = document.querySelector(`.commit[data-hash="${COMMIT_HASH_2}"]`);
+      expect(row2).not.toBeNull();
+      expect(row2!.classList.contains("compareTarget")).toBe(false);
+    });
+
+    it("normal click in compare mode cancels compare and shows new detail (TC-FI-N-05)", () => {
+      // Given: compare mode active between commit 1 and commit 2
+      expandCommitWithCompare(COMMIT_HASH_1, COMMIT_HASH_2);
+
+      // When: commit 3 is clicked without modifier keys (normal click)
+      clickCommit(COMMIT_HASH_3);
+
+      // Then: commitDetails message is sent for commit 3 (not compareCommits)
+      expect(vscode.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: "commitDetails",
+          commitHash: COMMIT_HASH_3
+        })
+      );
+
+      // Then: no compareCommits message was sent
+      const compareCalls = vi
+        .mocked(vscode.postMessage)
+        .mock.calls.filter(
+          (call) => (call[0] as Record<string, unknown>).command === "compareCommits"
+        );
+      expect(compareCalls).toHaveLength(0);
+    });
+
+    it("Ctrl+click without expanded commit shows normal detail (TC-FI-B-01)", () => {
+      // Given: no expanded commit (clean state from resetCommitState)
+      // When: commit 1 is Ctrl+clicked
+      clickCommit(COMMIT_HASH_1, { ctrlKey: true });
+
+      // Then: commitDetails message is sent (normal detail, not compareCommits)
+      expect(vscode.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: "commitDetails",
+          commitHash: COMMIT_HASH_1
+        })
+      );
+
+      // Then: no compareCommits message was sent
+      const compareCalls = vi
+        .mocked(vscode.postMessage)
+        .mock.calls.filter(
+          (call) => (call[0] as Record<string, unknown>).command === "compareCommits"
+        );
+      expect(compareCalls).toHaveLength(0);
+    });
+
+    it("uncommitted changes as expanded commit + Ctrl+click sends compare with fromHash='*' (TC-FI-B-02)", () => {
+      // Given: commits including uncommitted changes as first entry
+      const commitsWithUncommitted: GitCommitNode[] = [
+        {
+          hash: UNCOMMITTED_CHANGES_HASH,
+          parentHashes: [],
+          author: "*",
+          email: "",
+          date: 1700003000,
+          message: "Uncommitted Changes (3)",
+          refs: [],
+          stash: null
+        },
+        ...MOCK_COMMITS
+      ];
+      dispatchMessage({
+        command: "loadCommits",
+        commits: commitsWithUncommitted,
+        head: COMMIT_HASH_1,
+        moreCommitsAvailable: false,
+        hard: true
+      });
+      vi.clearAllMocks();
+
+      // When: unsaved changes row is clicked to expand it
+      clickUnsavedChanges();
+
+      // Then: commitDetails request is sent for "*"
+      expect(vscode.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: "commitDetails",
+          commitHash: UNCOMMITTED_CHANGES_HASH
+        })
+      );
+
+      // Simulate commitDetails response for "*"
+      dispatchMessage({
+        command: "commitDetails",
+        commitDetails: makeCommitDetails(UNCOMMITTED_CHANGES_HASH)
+      });
+      vi.clearAllMocks();
+
+      // When: a regular commit is Ctrl+clicked
+      clickCommit(COMMIT_HASH_1, { ctrlKey: true });
+
+      // Then: compareCommits message is sent with fromHash = UNCOMMITTED_CHANGES_HASH
+      expect(vscode.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: "compareCommits",
+          fromHash: UNCOMMITTED_CHANGES_HASH,
+          toHash: COMMIT_HASH_1
+        })
+      );
+
+      // Restore normal commits for subsequent tests
+      dispatchMessage({
+        command: "loadCommits",
+        commits: MOCK_COMMITS,
+        head: COMMIT_HASH_1,
+        moreCommitsAvailable: false,
+        hard: true
+      });
+    });
+  });
+
+  /* ---------------------------------------------------------------- */
+  /* Comparison response processing                                   */
+  /* ---------------------------------------------------------------- */
+
+  describe("comparison response processing", () => {
+    it("ResponseCompareCommits with fileChanges shows compare details (TC-FI-N-06)", () => {
+      // Given: commit 1 is expanded
+      expandCommit(COMMIT_HASH_1);
+
+      // When: Ctrl+click commit 2 and receive compareCommits response
+      clickCommit(COMMIT_HASH_2, { ctrlKey: true });
+      dispatchMessage({
+        command: "compareCommits",
+        fileChanges: [
+          {
+            oldFilePath: "src/app.ts",
+            newFilePath: "src/app.ts",
+            type: "M",
+            additions: 10,
+            deletions: 3
+          }
+        ],
+        fromHash: COMMIT_HASH_1,
+        toHash: COMMIT_HASH_2
+      });
+
+      // Then: commitDetails DOM element is created with "Comparing" text
+      const detailsElem = document.getElementById("commitDetails");
+      expect(detailsElem).not.toBeNull();
+      expect(detailsElem!.innerHTML).toContain("Comparing");
+    });
+
+    it("ResponseCompareCommits with fileChanges: null shows error dialog (TC-FI-A-01)", () => {
+      // Given: commit 1 is expanded
+      expandCommit(COMMIT_HASH_1);
+
+      // When: Ctrl+click commit 2 and receive compareCommits response with null fileChanges
+      clickCommit(COMMIT_HASH_2, { ctrlKey: true });
+      vi.clearAllMocks();
+      dispatchMessage({
+        command: "compareCommits",
+        fileChanges: null,
+        fromHash: COMMIT_HASH_1,
+        toHash: COMMIT_HASH_2
+      });
+
+      // Then: showErrorDialog is called with "Unable to load commit comparison"
+      expect(showErrorDialog).toHaveBeenCalledTimes(1);
+      expect(showErrorDialog).toHaveBeenCalledWith("Unable to load commit comparison", null, null);
+    });
+
+    it("file click in compare mode includes compareWithHash in viewDiff (TC-FI-N-07)", () => {
+      // Given: compare mode active with file tree HTML containing a clickable file
+      expandCommit(COMMIT_HASH_1);
+
+      // Override generateGitFileTreeHtml to return a clickable file element
+      vi.mocked(generateGitFileTreeHtml).mockReturnValueOnce(
+        '<table><tr class="gitFile gitDiffPossible" data-oldfilepath="old.ts" data-newfilepath="new.ts" data-type="M"><td>new.ts</td></tr></table>'
+      );
+
+      // Ctrl+click commit 2 and receive compare result
+      clickCommit(COMMIT_HASH_2, { ctrlKey: true });
+      dispatchMessage({
+        command: "compareCommits",
+        fileChanges: [
+          {
+            oldFilePath: "old.ts",
+            newFilePath: "new.ts",
+            type: "M",
+            additions: 5,
+            deletions: 2
+          }
+        ],
+        fromHash: COMMIT_HASH_1,
+        toHash: COMMIT_HASH_2
+      });
+      vi.clearAllMocks();
+
+      // When: a file element in the commit details is clicked
+      const fileElem = document.querySelector(".gitFile.gitDiffPossible");
+      expect(fileElem).not.toBeNull();
+      fileElem!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+      // Then: viewDiff message includes compareWithHash
+      expect(vscode.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: "viewDiff",
+          commitHash: COMMIT_HASH_1,
+          oldFilePath: "old.ts",
+          newFilePath: "new.ts",
+          type: "M",
+          compareWithHash: COMMIT_HASH_2
+        })
+      );
+    });
+
+    it("accepts ResponseCompareCommits with reordered fromHash/toHash (TC-FI-N-15)", () => {
+      // Given: commit 1 is expanded
+      expandCommit(COMMIT_HASH_1);
+
+      // When: Ctrl+click commit 2, then response arrives with hashes in reversed order
+      clickCommit(COMMIT_HASH_2, { ctrlKey: true });
+      dispatchMessage({
+        command: "compareCommits",
+        fileChanges: [
+          {
+            oldFilePath: "src/app.ts",
+            newFilePath: "src/app.ts",
+            type: "M",
+            additions: 3,
+            deletions: 1
+          }
+        ],
+        fromHash: COMMIT_HASH_2,
+        toHash: COMMIT_HASH_1
+      });
+
+      // Then: compare details are shown correctly (set-based validation accepts reordered hashes)
+      const detailsElem = document.getElementById("commitDetails");
+      expect(detailsElem).not.toBeNull();
+      expect(detailsElem!.innerHTML).toContain("Comparing");
+    });
+
+    it("restores unsavedChanges srcElem after table re-render (TC-FI-N-16)", () => {
+      // Given: commits with uncommitted changes, uncommitted row is expanded
+      const commitsWithUncommitted: GitCommitNode[] = [
+        {
+          hash: UNCOMMITTED_CHANGES_HASH,
+          parentHashes: [],
+          author: "*",
+          email: "",
+          date: 1700003000,
+          message: "Uncommitted Changes (3)",
+          refs: [],
+          stash: null
+        },
+        ...MOCK_COMMITS
+      ];
+      dispatchMessage({
+        command: "loadCommits",
+        commits: commitsWithUncommitted,
+        head: COMMIT_HASH_1,
+        moreCommitsAvailable: false,
+        hard: true
+      });
+      vi.clearAllMocks();
+
+      // Expand the unsaved changes row
+      clickUnsavedChanges();
+      dispatchMessage({
+        command: "commitDetails",
+        commitDetails: makeCommitDetails(UNCOMMITTED_CHANGES_HASH)
+      });
+
+      // When: loadCommits is dispatched again (triggers table re-render)
+      dispatchMessage({
+        command: "loadCommits",
+        commits: commitsWithUncommitted,
+        head: COMMIT_HASH_1,
+        moreCommitsAvailable: false,
+        hard: true
+      });
+
+      // Then: the unsavedChanges row still exists and commitDetails area is present
+      const unsavedRow = document.querySelector(".unsavedChanges");
+      expect(unsavedRow).not.toBeNull();
+      const detailsElem = document.getElementById("commitDetails");
+      expect(detailsElem).not.toBeNull();
+
+      // Restore normal commits
+      dispatchMessage({
+        command: "loadCommits",
+        commits: MOCK_COMMITS,
+        head: COMMIT_HASH_1,
+        moreCommitsAvailable: false,
+        hard: true
+      });
+    });
+  });
+
+  /* ---------------------------------------------------------------- */
+  /* Unsaved changes Ctrl+click comparison (bugfix 52a5aa8)           */
+  /* ---------------------------------------------------------------- */
+
+  describe("unsaved changes Ctrl+click comparison", () => {
+    function loadCommitsWithUncommitted(): void {
+      const commitsWithUncommitted: GitCommitNode[] = [
+        {
+          hash: UNCOMMITTED_CHANGES_HASH,
+          parentHashes: [],
+          author: "*",
+          email: "",
+          date: 1700003000,
+          message: "Uncommitted Changes (3)",
+          refs: [],
+          stash: null
+        },
+        ...MOCK_COMMITS
+      ];
+      dispatchMessage({
+        command: "loadCommits",
+        commits: commitsWithUncommitted,
+        head: COMMIT_HASH_1,
+        moreCommitsAvailable: false,
+        hard: true
+      });
+      vi.clearAllMocks();
+    }
+
+    function restoreNormalCommits(): void {
+      dispatchMessage({
+        command: "loadCommits",
+        commits: MOCK_COMMITS,
+        head: COMMIT_HASH_1,
+        moreCommitsAvailable: false,
+        hard: true
+      });
+    }
+
+    it("Ctrl+click unsaved changes row enters compare mode with UNCOMMITTED_CHANGES_HASH as fromHash (TC-FI-N-12)", () => {
+      // Given: commits with uncommitted changes loaded, commit 1 is expanded
+      loadCommitsWithUncommitted();
+      expandCommit(COMMIT_HASH_1);
+
+      // When: unsaved changes row is Ctrl+clicked
+      clickUnsavedChanges({ ctrlKey: true });
+
+      // Then: compareCommits message is sent with UNCOMMITTED_CHANGES_HASH as fromHash
+      expect(vscode.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: "compareCommits",
+          fromHash: UNCOMMITTED_CHANGES_HASH,
+          toHash: COMMIT_HASH_1
+        })
+      );
+
+      restoreNormalCommits();
+    });
+
+    it("Ctrl+click same unsaved changes row cancels comparison (TC-FI-N-13)", () => {
+      // Given: commits with uncommitted changes, compare mode active with unsaved changes
+      loadCommitsWithUncommitted();
+      expandCommit(COMMIT_HASH_1);
+      clickUnsavedChanges({ ctrlKey: true });
+      // Simulate compare response
+      dispatchMessage({
+        command: "compareCommits",
+        fileChanges: [
+          { oldFilePath: "f.ts", newFilePath: "f.ts", type: "M", additions: 1, deletions: 0 }
+        ],
+        fromHash: UNCOMMITTED_CHANGES_HASH,
+        toHash: COMMIT_HASH_1
+      });
+      vi.clearAllMocks();
+
+      // When: same unsaved changes row is Ctrl+clicked again
+      clickUnsavedChanges({ ctrlKey: true });
+
+      // Then: no compareCommits message is sent (comparison canceled)
+      const compareCalls = vi
+        .mocked(vscode.postMessage)
+        .mock.calls.filter(
+          (call) => (call[0] as Record<string, unknown>).command === "compareCommits"
+        );
+      expect(compareCalls).toHaveLength(0);
+
+      restoreNormalCommits();
+    });
+
+    it("normal click on unsaved changes sends commitDetails (TC-FI-N-14)", () => {
+      // Given: commits with uncommitted changes loaded, no expanded commit
+      loadCommitsWithUncommitted();
+
+      // When: unsaved changes row is clicked without modifier keys
+      clickUnsavedChanges();
+
+      // Then: commitDetails message is sent for UNCOMMITTED_CHANGES_HASH
+      expect(vscode.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: "commitDetails",
+          commitHash: UNCOMMITTED_CHANGES_HASH
+        })
+      );
+
+      restoreNormalCommits();
+    });
+  });
+
+  /* ---------------------------------------------------------------- */
+  /* FindWidget integration                                           */
+  /* ---------------------------------------------------------------- */
+
+  describe("FindWidget integration", () => {
+    it("Ctrl+F triggers FindWidget.show() (TC-FI-N-08)", () => {
+      // Given: the page is loaded with commits rendered
+      // When: Ctrl+F keyboard shortcut is pressed
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "f",
+          ctrlKey: true,
+          bubbles: true
+        })
+      );
+
+      // Then: FindWidget.show is called with transition = true
+      expect(mockFindWidgetInstance.show).toHaveBeenCalledTimes(1);
+      expect(mockFindWidgetInstance.show).toHaveBeenCalledWith(true);
+    });
+
+    it("search button click triggers FindWidget.show() (TC-FI-N-09)", () => {
+      // Given: the page is loaded with commits rendered
+      const searchBtn = document.getElementById("searchBtn");
+      expect(searchBtn).not.toBeNull();
+
+      // When: the search button is clicked
+      searchBtn!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+      // Then: FindWidget.show is called with transition = true
+      expect(mockFindWidgetInstance.show).toHaveBeenCalledTimes(1);
+      expect(mockFindWidgetInstance.show).toHaveBeenCalledWith(true);
+    });
+
+    it("saveState includes findWidgetState from FindWidget.getState() (TC-FI-N-10)", () => {
+      // Given: FindWidget.getState returns a specific state
+      const expectedFindState = {
+        text: "",
+        currentHash: null,
+        visible: false,
+        caseSensitive: false,
+        regex: false
+      };
+      mockFindWidgetInstance.getState.mockReturnValue(expectedFindState);
+
+      // When: an action that triggers saveState occurs (clicking a commit triggers it)
+      clickCommit(COMMIT_HASH_1);
+
+      // Then: vscode.setState was called with an object containing findWidgetState
+      expect(vscode.setState).toHaveBeenCalled();
+      const lastSetStateCall = vi.mocked(vscode.setState).mock.calls.at(-1);
+      expect(lastSetStateCall).toBeDefined();
+      const savedState = lastSetStateCall![0] as WebViewState;
+      expect(savedState.findWidgetState).toEqual(expectedFindState);
+    });
+
+    it("restoreState is called with findWidgetState during initialization (TC-FI-N-11)", () => {
+      // Given: prevState had findWidgetState set (configured in beforeAll)
+      // When: GitGraphView was constructed (in beforeAll)
+      // Then: findWidget.restoreState was called during initialization
+      expect(restoreStateCaptured).toBe(true);
+    });
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* FindWidget backward compatibility (separate module scope)          */
+/* ------------------------------------------------------------------ */
+
+describe("GitGraphView findWidgetState backward compatibility", () => {
+  it("prevState without findWidgetState does not call restoreState (TC-FI-B-03)", async () => {
+    // Given: a fresh module scope
+    vi.resetModules();
+    setupTestDOM();
+    setupViewState();
+
+    // Re-import utils to get the fresh vscode mock
+    const { vscode: freshVscode } = await import("../../web/utils");
+    const prevStateWithoutFindWidget = {
+      ...MOCK_PREV_STATE,
+      findWidgetState: undefined
+    };
+    vi.mocked(freshVscode.getState).mockReturnValueOnce(
+      prevStateWithoutFindWidget as unknown as ReturnType<typeof freshVscode.getState>
+    );
+    mockFindWidgetInstance.restoreState.mockClear();
+
+    // When: main module is imported (creates GitGraphView)
+    await import("../../web/main");
+
+    // Then: FindWidget.restoreState was NOT called
+    expect(mockFindWidgetInstance.restoreState).not.toHaveBeenCalled();
+  });
+});

--- a/tests/web/utils.test.ts
+++ b/tests/web/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { arraysEqual, escapeHtml, pad2, unescapeHtml } from "../../web/utils";
+import { arraysEqual, escapeHtml, pad2, svgIcons, unescapeHtml } from "../../web/utils";
 
 describe("escapeHtml", () => {
   it("escapes ampersand", () => {
@@ -92,6 +92,26 @@ describe("arraysEqual", () => {
     const a = [{ id: 1 }, { id: 2 }];
     const b = [{ id: 1 }, { id: 3 }];
     expect(arraysEqual(a, b, (x, y) => x.id === y.id)).toBe(false);
+  });
+});
+
+describe("svgIcons", () => {
+  it("fetch icon is a non-empty SVG string (TC-F-N-04)", () => {
+    // Given: svgIcons is imported
+    // When: fetch property is referenced
+    // Then: it is a non-empty string containing "<svg"
+    expect(typeof svgIcons.fetch).toBe("string");
+    expect(svgIcons.fetch.length).toBeGreaterThan(0);
+    expect(svgIcons.fetch).toContain("<svg");
+  });
+
+  it("stash icon is a non-empty SVG string (TC-F-N-05)", () => {
+    // Given: svgIcons is imported
+    // When: stash property is referenced
+    // Then: it is a non-empty string containing "<svg"
+    expect(typeof svgIcons.stash).toBe("string");
+    expect(svgIcons.stash.length).toBeGreaterThan(0);
+    expect(svgIcons.stash).toContain("<svg");
   });
 });
 

--- a/web/commitMenu.ts
+++ b/web/commitMenu.ts
@@ -1,0 +1,233 @@
+import type { GitCommitNode, GitResetMode } from "../src/types";
+import {
+  showCheckboxDialog,
+  showConfirmationDialog,
+  showFormDialog,
+  showRefInputDialog,
+  showSelectDialog
+} from "./dialogs";
+import { abbrevCommit, ELLIPSIS, sendMessage } from "./utils";
+
+export function buildCommitContextMenuItems(
+  repo: string,
+  hash: string,
+  parentHashes: string[],
+  commits: GitCommitNode[],
+  commitLookup: { [hash: string]: number },
+  sourceElem: HTMLElement
+): ContextMenuElement[] {
+  return [
+    {
+      title: `Add Tag${ELLIPSIS}`,
+      onClick: () => {
+        showFormDialog(
+          `Add tag to commit <b><i>${abbrevCommit(hash)}</i></b>:`,
+          [
+            { type: "text-ref" as const, name: "Name: ", default: "" },
+            {
+              type: "select" as const,
+              name: "Type: ",
+              default: "annotated",
+              options: [
+                { name: "Annotated", value: "annotated" },
+                { name: "Lightweight", value: "lightweight" }
+              ]
+            },
+            {
+              type: "text" as const,
+              name: "Message: ",
+              default: "",
+              placeholder: "Optional"
+            }
+          ],
+          "Add Tag",
+          (values) => {
+            sendMessage({
+              command: "addTag",
+              repo: repo,
+              tagName: values[0],
+              commitHash: hash,
+              lightweight: values[1] === "lightweight",
+              message: values[2]
+            });
+          },
+          sourceElem
+        );
+      }
+    },
+    {
+      title: `Create Branch${ELLIPSIS}`,
+      onClick: () => {
+        showRefInputDialog(
+          `Enter the name of the branch you would like to create from commit <b><i>${abbrevCommit(hash)}</i></b>:`,
+          "",
+          "Create Branch",
+          (name) => {
+            sendMessage({
+              command: "createBranch",
+              repo: repo,
+              branchName: name,
+              commitHash: hash
+            });
+          },
+          sourceElem
+        );
+      }
+    },
+    null,
+    {
+      title: `Checkout${ELLIPSIS}`,
+      onClick: () => {
+        showConfirmationDialog(
+          `Are you sure you want to checkout commit <b><i>${abbrevCommit(hash)}</i></b>? This will result in a 'detached HEAD' state.`,
+          () => {
+            sendMessage({
+              command: "checkoutCommit",
+              repo: repo,
+              commitHash: hash
+            });
+          },
+          sourceElem
+        );
+      }
+    },
+    {
+      title: `Cherry Pick${ELLIPSIS}`,
+      onClick: () => {
+        if (parentHashes.length === 1) {
+          showConfirmationDialog(
+            `Are you sure you want to cherry pick commit <b><i>${abbrevCommit(hash)}</i></b>?`,
+            () => {
+              sendMessage({
+                command: "cherrypickCommit",
+                repo: repo,
+                commitHash: hash,
+                parentIndex: 0
+              });
+            },
+            sourceElem
+          );
+        } else {
+          let options = parentHashes.map((parentHash, index) => ({
+            name: `${abbrevCommit(parentHash)}${
+              typeof commitLookup[parentHash] === "number"
+                ? `: ${commits[commitLookup[parentHash]].message}`
+                : ""
+            }`,
+            value: (index + 1).toString()
+          }));
+          showSelectDialog(
+            `Are you sure you want to cherry pick merge commit <b><i>${abbrevCommit(hash)}</i></b>? Choose the parent hash on the main branch, to cherry pick the commit relative to:`,
+            "1",
+            options,
+            "Yes, cherry pick commit",
+            (parentIndex) => {
+              sendMessage({
+                command: "cherrypickCommit",
+                repo: repo,
+                commitHash: hash,
+                parentIndex: parseInt(parentIndex, 10)
+              });
+            },
+            sourceElem
+          );
+        }
+      }
+    },
+    {
+      title: `Revert${ELLIPSIS}`,
+      onClick: () => {
+        if (parentHashes.length === 1) {
+          showConfirmationDialog(
+            `Are you sure you want to revert commit <b><i>${abbrevCommit(hash)}</i></b>?`,
+            () => {
+              sendMessage({
+                command: "revertCommit",
+                repo: repo,
+                commitHash: hash,
+                parentIndex: 0
+              });
+            },
+            sourceElem
+          );
+        } else {
+          let options = parentHashes.map((parentHash, index) => ({
+            name: `${abbrevCommit(parentHash)}${
+              typeof commitLookup[parentHash] === "number"
+                ? `: ${commits[commitLookup[parentHash]].message}`
+                : ""
+            }`,
+            value: (index + 1).toString()
+          }));
+          showSelectDialog(
+            `Are you sure you want to revert merge commit <b><i>${abbrevCommit(hash)}</i></b>? Choose the parent hash on the main branch, to revert the commit relative to:`,
+            "1",
+            options,
+            "Yes, revert commit",
+            (parentIndex) => {
+              sendMessage({
+                command: "revertCommit",
+                repo: repo,
+                commitHash: hash,
+                parentIndex: parseInt(parentIndex, 10)
+              });
+            },
+            sourceElem
+          );
+        }
+      }
+    },
+    null,
+    {
+      title: `Merge into current branch${ELLIPSIS}`,
+      onClick: () => {
+        showCheckboxDialog(
+          `Are you sure you want to merge commit <b><i>${abbrevCommit(hash)}</i></b> into the current branch?`,
+          "Create a new commit even if fast-forward is possible",
+          true,
+          "Yes, merge",
+          (createNewCommit) => {
+            sendMessage({
+              command: "mergeCommit",
+              repo: repo,
+              commitHash: hash,
+              createNewCommit: createNewCommit
+            });
+          },
+          null
+        );
+      }
+    },
+    {
+      title: `Reset current branch to this Commit${ELLIPSIS}`,
+      onClick: () => {
+        showSelectDialog(
+          `Are you sure you want to reset the <b>current branch</b> to commit <b><i>${abbrevCommit(hash)}</i></b>?`,
+          "mixed",
+          [
+            { name: "Soft - Keep all changes, but reset head", value: "soft" },
+            { name: "Mixed - Keep working tree, but reset index", value: "mixed" },
+            { name: "Hard - Discard all changes", value: "hard" }
+          ],
+          "Yes, reset",
+          (mode) => {
+            sendMessage({
+              command: "resetToCommit",
+              repo: repo,
+              commitHash: hash,
+              resetMode: mode as GitResetMode
+            });
+          },
+          sourceElem
+        );
+      }
+    },
+    null,
+    {
+      title: "Copy Commit Hash to Clipboard",
+      onClick: () => {
+        sendMessage({ command: "copyToClipboard", type: "Commit Hash", data: hash });
+      }
+    }
+  ];
+}

--- a/web/findWidget.ts
+++ b/web/findWidget.ts
@@ -1,0 +1,489 @@
+import * as GG from "../src/types";
+import { getBranchLabels } from "./branchLabels";
+import { getCommitDate } from "./dates";
+import { svgIcons, UNCOMMITTED_CHANGES_HASH } from "./utils";
+
+/* === Constants === */
+
+export const SEARCH_DEBOUNCE_MS = 200;
+export const CLASS_FIND_MATCH = "findMatch";
+export const CLASS_FIND_CURRENT_COMMIT = "findCurrentCommit";
+export const REGEX_META_CHARS = /[\\[\](){}|.*+?^$]/g;
+
+const CLASS_ACTIVE = "active";
+const CLASS_TRANSITION = "transition";
+const CLASS_DISABLED = "disabled";
+const ATTR_ERROR = "data-error";
+const ABBREV_COMMIT_LENGTH = 8;
+const ZERO_LENGTH_MATCH_ERROR = "Cannot use a regular expression which has zero length matches";
+
+/* === DOM Helpers === */
+
+function getCommitElems(): HTMLCollectionOf<HTMLElement> {
+  return document.getElementsByClassName("commit") as HTMLCollectionOf<HTMLElement>;
+}
+
+function getChildNodesWithTextContent(elem: Node): Node[] {
+  const textChildren: Node[] = [];
+  for (let i = 0; i < elem.childNodes.length; i++) {
+    if (elem.childNodes[i].childNodes.length > 0) {
+      textChildren.push(...getChildNodesWithTextContent(elem.childNodes[i]));
+    } else if (elem.childNodes[i].textContent !== null && elem.childNodes[i].textContent !== "") {
+      textChildren.push(elem.childNodes[i]);
+    }
+  }
+  return textChildren;
+}
+
+function getChildrenWithClassName(elem: Element, className: string): Element[] {
+  const children: Element[] = [];
+  for (let i = 0; i < elem.children.length; i++) {
+    if (elem.children[i].children.length > 0) {
+      children.push(...getChildrenWithClassName(elem.children[i], className));
+    } else if (elem.children[i].className === className) {
+      children.push(elem.children[i]);
+    }
+  }
+  return children;
+}
+
+function findCommitElemWithId(
+  elems: HTMLCollectionOf<HTMLElement>,
+  id: number | null
+): HTMLElement | null {
+  if (id === null) return null;
+  const findIdStr = id.toString();
+  for (let i = 0; i < elems.length; i++) {
+    if (findIdStr === elems[i].dataset.id) return elems[i];
+  }
+  return null;
+}
+
+function abbrevCommit(commitHash: string): string {
+  return commitHash.substring(0, ABBREV_COMMIT_LENGTH);
+}
+
+/* === Interfaces === */
+
+export interface FindWidgetCallbacks {
+  getCommits(): GG.GitCommitNode[];
+  getColumnVisibility(): { author: boolean; date: boolean; commit: boolean };
+  scrollToCommit(hash: string, alwaysCenterCommit: boolean): void;
+  saveState(): void;
+  loadCommitDetails(elem: HTMLElement): void;
+  getCommitId(hash: string): number | null;
+  isCdvOpen(hash: string, compareWithHash: string | null): boolean;
+}
+
+/* === FindWidget === */
+
+export class FindWidget {
+  private readonly callbacks: FindWidgetCallbacks;
+  private text: string = "";
+  private matches: { hash: string; elem: HTMLElement }[] = [];
+  private position: number = -1;
+  private visible: boolean = false;
+  private caseSensitive: boolean = false;
+  private regex: boolean = false;
+  private openCdvEnabled: boolean = false;
+
+  private readonly widgetElem: HTMLElement;
+  private readonly inputElem: HTMLInputElement;
+  private readonly caseSensitiveElem: HTMLElement;
+  private readonly regexElem: HTMLElement;
+  private readonly positionElem: HTMLElement;
+  private readonly prevElem: HTMLElement;
+  private readonly nextElem: HTMLElement;
+  private readonly openCdvElem: HTMLElement;
+
+  constructor(callbacks: FindWidgetCallbacks) {
+    this.callbacks = callbacks;
+
+    this.widgetElem = document.createElement("div");
+    this.widgetElem.className = "findWidget";
+    this.widgetElem.innerHTML = [
+      '<input id="findInput" type="text" placeholder="Find" disabled/>',
+      '<span id="findCaseSensitive" class="findModifier" title="Match Case">Aa</span>',
+      '<span id="findRegex" class="findModifier" title="Use Regular Expression">.*</span>',
+      '<span id="findPosition"></span>',
+      '<span id="findPrev" title="Previous match (Shift+Enter)"></span>',
+      '<span id="findNext" title="Next match (Enter)"></span>',
+      '<span id="findOpenCdv" title="Open the Commit Details View for the current match"></span>',
+      '<span id="findClose" title="Close (Escape)"></span>'
+    ].join("");
+    document.body.appendChild(this.widgetElem);
+
+    this.inputElem = document.getElementById("findInput") as HTMLInputElement;
+    let keyupTimeout: ReturnType<typeof setTimeout> | null = null;
+    this.inputElem.addEventListener("keyup", (e) => {
+      if (e.key === "Enter" && this.text !== "") {
+        if (e.shiftKey) {
+          this.prev();
+        } else {
+          this.next();
+        }
+        e.stopPropagation();
+      } else {
+        if (keyupTimeout !== null) clearTimeout(keyupTimeout);
+        keyupTimeout = setTimeout(() => {
+          keyupTimeout = null;
+          if (this.text !== this.inputElem.value) {
+            this.text = this.inputElem.value;
+            this.clearMatches();
+            this.findMatches(this.getCurrentHash(), true);
+            this.openCommitDetailsViewForCurrentMatchIfEnabled();
+          }
+        }, SEARCH_DEBOUNCE_MS);
+      }
+    });
+
+    this.caseSensitiveElem = document.getElementById("findCaseSensitive")!;
+    this.toggleClass(this.caseSensitiveElem, CLASS_ACTIVE, this.caseSensitive);
+    this.caseSensitiveElem.addEventListener("click", () => {
+      this.caseSensitive = !this.caseSensitive;
+      this.toggleClass(this.caseSensitiveElem, CLASS_ACTIVE, this.caseSensitive);
+      this.clearMatches();
+      this.findMatches(this.getCurrentHash(), true);
+      this.openCommitDetailsViewForCurrentMatchIfEnabled();
+    });
+
+    this.regexElem = document.getElementById("findRegex")!;
+    this.toggleClass(this.regexElem, CLASS_ACTIVE, this.regex);
+    this.regexElem.addEventListener("click", () => {
+      this.regex = !this.regex;
+      this.toggleClass(this.regexElem, CLASS_ACTIVE, this.regex);
+      this.clearMatches();
+      this.findMatches(this.getCurrentHash(), true);
+      this.openCommitDetailsViewForCurrentMatchIfEnabled();
+    });
+
+    this.positionElem = document.getElementById("findPosition")!;
+
+    this.prevElem = document.getElementById("findPrev")!;
+    this.prevElem.classList.add(CLASS_DISABLED);
+    this.prevElem.innerHTML = svgIcons.arrowUp;
+    this.prevElem.addEventListener("click", () => this.prev());
+
+    this.nextElem = document.getElementById("findNext")!;
+    this.nextElem.classList.add(CLASS_DISABLED);
+    this.nextElem.innerHTML = svgIcons.arrowDown;
+    this.nextElem.addEventListener("click", () => this.next());
+
+    this.openCdvElem = document.getElementById("findOpenCdv")!;
+    this.openCdvElem.innerHTML = svgIcons.cdv;
+    this.toggleClass(this.openCdvElem, CLASS_ACTIVE, this.openCdvEnabled);
+    this.openCdvElem.addEventListener("click", () => {
+      this.openCdvEnabled = !this.openCdvEnabled;
+      this.toggleClass(this.openCdvElem, CLASS_ACTIVE, this.openCdvEnabled);
+      this.openCommitDetailsViewForCurrentMatchIfEnabled();
+    });
+
+    const findCloseElem = document.getElementById("findClose")!;
+    findCloseElem.innerHTML = svgIcons.close;
+    findCloseElem.addEventListener("click", () => this.close());
+  }
+
+  /* === Public Methods === */
+
+  public show(transition: boolean) {
+    if (!this.visible) {
+      this.visible = true;
+      this.inputElem.value = this.text;
+      this.inputElem.disabled = false;
+      this.updatePosition(-1, false);
+      this.toggleClass(this.widgetElem, CLASS_TRANSITION, transition);
+      this.widgetElem.classList.add(CLASS_ACTIVE);
+    }
+    this.inputElem.focus();
+    this.inputElem.select();
+  }
+
+  public close() {
+    if (!this.visible) return;
+    this.visible = false;
+    this.widgetElem.classList.add(CLASS_TRANSITION);
+    this.widgetElem.classList.remove(CLASS_ACTIVE);
+    this.clearMatches();
+    this.text = "";
+    this.matches = [];
+    this.position = -1;
+    this.inputElem.value = this.text;
+    this.inputElem.disabled = true;
+    this.widgetElem.removeAttribute(ATTR_ERROR);
+    this.prevElem.classList.add(CLASS_DISABLED);
+    this.nextElem.classList.add(CLASS_DISABLED);
+    this.callbacks.saveState();
+  }
+
+  public refresh() {
+    if (this.visible) {
+      this.findMatches(this.getCurrentHash(), false);
+    }
+  }
+
+  public isVisible() {
+    return this.visible;
+  }
+
+  public setInputEnabled(enabled: boolean) {
+    if (!this.visible) return;
+    this.inputElem.disabled = !enabled;
+  }
+
+  /* === State === */
+
+  public getState(): FindWidgetState {
+    return {
+      text: this.text,
+      currentHash: this.getCurrentHash(),
+      visible: this.visible,
+      caseSensitive: this.caseSensitive,
+      regex: this.regex
+    };
+  }
+
+  public getCurrentHash(): string | null {
+    return this.position > -1 ? this.matches[this.position].hash : null;
+  }
+
+  public restoreState(state: FindWidgetState) {
+    if (!state.visible) return;
+    this.text = state.text;
+    this.caseSensitive = state.caseSensitive;
+    this.regex = state.regex;
+    this.toggleClass(this.caseSensitiveElem, CLASS_ACTIVE, this.caseSensitive);
+    this.toggleClass(this.regexElem, CLASS_ACTIVE, this.regex);
+    this.show(false);
+    if (this.text !== "") this.findMatches(state.currentHash, false);
+  }
+
+  /* === Matching === */
+
+  private findMatches(goToCommitHash: string | null, scrollToCommit: boolean) {
+    this.matches = [];
+    this.position = -1;
+
+    if (this.text !== "") {
+      const colVisibility = this.callbacks.getColumnVisibility();
+      const regexText = this.regex ? this.text : this.text.replace(REGEX_META_CHARS, "\\$&");
+      const flags = `u${this.caseSensitive ? "" : "i"}`;
+
+      let findPattern: RegExp | null;
+      let findGlobalPattern: RegExp | null;
+      try {
+        findPattern = new RegExp(regexText, flags);
+        findGlobalPattern = new RegExp(regexText, `g${flags}`);
+        this.widgetElem.removeAttribute(ATTR_ERROR);
+      } catch (e) {
+        findPattern = null;
+        findGlobalPattern = null;
+        this.widgetElem.setAttribute(ATTR_ERROR, e instanceof Error ? e.message : String(e));
+      }
+
+      if (findPattern !== null && findGlobalPattern !== null) {
+        const commitElems = getCommitElems();
+        let j = 0;
+        let zeroLengthMatch = false;
+
+        const commits = this.callbacks.getCommits();
+        for (let i = 0; i < commits.length; i++) {
+          const commit = commits[i];
+          const branchLabels = getBranchLabels(commit.refs);
+
+          if (
+            commit.hash !== UNCOMMITTED_CHANGES_HASH &&
+            (findPattern.test(commit.message) ||
+              (colVisibility.author && findPattern.test(commit.author)) ||
+              (colVisibility.commit &&
+                (commit.hash.search(findPattern) === 0 ||
+                  findPattern.test(abbrevCommit(commit.hash)))) ||
+              branchLabels.heads.some(
+                (head) =>
+                  findPattern!.test(head.name) ||
+                  head.remotes.some((remote) => findPattern!.test(remote))
+              ) ||
+              branchLabels.remotes.some((remote) => findPattern!.test(remote.name)) ||
+              branchLabels.tags.some((tag) => findPattern!.test(tag.name)) ||
+              (colVisibility.date && findPattern.test(getCommitDate(commit.date).value)) ||
+              (commit.stash !== null && findPattern.test(commit.stash.selector)))
+          ) {
+            const idStr = i.toString();
+            while (j < commitElems.length && commitElems[j].dataset.id !== idStr) j++;
+            if (j === commitElems.length) continue;
+
+            this.matches.push({ hash: commit.hash, elem: commitElems[j] });
+
+            const textElems = getChildNodesWithTextContent(commitElems[j]);
+            for (let k = 0; k < textElems.length; k++) {
+              const textElem = textElems[k];
+              let matchStart = 0;
+              let matchEnd = 0;
+              const text = textElem.textContent!;
+              findGlobalPattern.lastIndex = 0;
+              let match: RegExpExecArray | null;
+              while ((match = findGlobalPattern.exec(text)) !== null) {
+                if (match[0].length === 0) {
+                  zeroLengthMatch = true;
+                  break;
+                }
+                if (matchEnd !== match.index) {
+                  if (matchStart !== matchEnd) {
+                    textElem.parentNode!.insertBefore(
+                      FindWidget.createMatchElem(text.substring(matchStart, matchEnd)),
+                      textElem
+                    );
+                  }
+                  textElem.parentNode!.insertBefore(
+                    document.createTextNode(text.substring(matchEnd, match.index)),
+                    textElem
+                  );
+                  matchStart = match.index;
+                }
+                matchEnd = findGlobalPattern.lastIndex;
+              }
+              if (matchEnd > 0) {
+                if (matchStart !== matchEnd) {
+                  textElem.parentNode!.insertBefore(
+                    FindWidget.createMatchElem(text.substring(matchStart, matchEnd)),
+                    textElem
+                  );
+                }
+                if (matchEnd !== text.length) {
+                  textElem.textContent = text.substring(matchEnd);
+                } else {
+                  textElem.parentNode!.removeChild(textElem);
+                }
+              }
+              if (zeroLengthMatch) break;
+            }
+
+            if (
+              colVisibility.commit &&
+              commit.hash.search(findPattern) === 0 &&
+              !findPattern.test(abbrevCommit(commit.hash)) &&
+              textElems.length > 0
+            ) {
+              const commitNode = textElems[textElems.length - 1];
+              commitNode.parentNode!.replaceChild(
+                FindWidget.createMatchElem(commitNode.textContent!),
+                commitNode
+              );
+            }
+
+            if (zeroLengthMatch) break;
+          }
+        }
+
+        if (zeroLengthMatch) {
+          this.widgetElem.setAttribute(ATTR_ERROR, ZERO_LENGTH_MATCH_ERROR);
+          this.clearMatches();
+          this.matches = [];
+        }
+      }
+    } else {
+      this.widgetElem.removeAttribute(ATTR_ERROR);
+    }
+
+    this.toggleClass(this.prevElem, CLASS_DISABLED, this.matches.length === 0);
+    this.toggleClass(this.nextElem, CLASS_DISABLED, this.matches.length === 0);
+
+    let newPos = -1;
+    if (this.matches.length > 0) {
+      newPos = 0;
+      if (goToCommitHash !== null) {
+        const pos = this.matches.findIndex((m) => m.hash === goToCommitHash);
+        if (pos > -1) newPos = pos;
+      }
+    }
+    this.updatePosition(newPos, scrollToCommit);
+  }
+
+  private clearMatches() {
+    for (let i = 0; i < this.matches.length; i++) {
+      if (i === this.position) {
+        this.matches[i].elem.classList.remove(CLASS_FIND_CURRENT_COMMIT);
+      }
+      const matchElems = getChildrenWithClassName(this.matches[i].elem, CLASS_FIND_MATCH);
+      for (let j = 0; j < matchElems.length; j++) {
+        const matchElem = matchElems[j];
+        let text = matchElem.childNodes[0].textContent!;
+
+        let node = matchElem.previousSibling;
+        const prevElementSibling = matchElem.previousElementSibling;
+        while (node !== null && node !== prevElementSibling && node.textContent !== null) {
+          text = node.textContent + text;
+          matchElem.parentNode!.removeChild(node);
+          node = matchElem.previousSibling;
+        }
+
+        node = matchElem.nextSibling;
+        const nextElementSibling = matchElem.nextElementSibling;
+        while (node !== null && node !== nextElementSibling && node.textContent !== null) {
+          text = text + node.textContent;
+          matchElem.parentNode!.removeChild(node);
+          node = matchElem.nextSibling;
+        }
+
+        matchElem.parentNode!.replaceChild(document.createTextNode(text), matchElem);
+      }
+    }
+  }
+
+  private updatePosition(position: number, scrollToCommit: boolean) {
+    if (this.position > -1) {
+      this.matches[this.position].elem.classList.remove(CLASS_FIND_CURRENT_COMMIT);
+    }
+    this.position = position;
+    if (this.position > -1) {
+      this.matches[this.position].elem.classList.add(CLASS_FIND_CURRENT_COMMIT);
+      if (scrollToCommit) {
+        this.callbacks.scrollToCommit(this.matches[position].hash, false);
+      }
+    }
+    this.positionElem.textContent =
+      this.matches.length > 0 ? `${this.position + 1} of ${this.matches.length}` : "No Results";
+    this.callbacks.saveState();
+  }
+
+  private prev() {
+    if (this.matches.length === 0) return;
+    this.updatePosition(this.position > 0 ? this.position - 1 : this.matches.length - 1, true);
+    this.openCommitDetailsViewForCurrentMatchIfEnabled();
+  }
+
+  private next() {
+    if (this.matches.length === 0) return;
+    this.updatePosition(this.position < this.matches.length - 1 ? this.position + 1 : 0, true);
+    this.openCommitDetailsViewForCurrentMatchIfEnabled();
+  }
+
+  private openCommitDetailsViewForCurrentMatchIfEnabled() {
+    if (!this.openCdvEnabled) return;
+    const commitHash = this.getCurrentHash();
+    if (commitHash === null || this.callbacks.isCdvOpen(commitHash, null)) return;
+    const commitElem = findCommitElemWithId(
+      getCommitElems(),
+      this.callbacks.getCommitId(commitHash)
+    );
+    if (commitElem !== null) {
+      this.callbacks.loadCommitDetails(commitElem);
+    }
+  }
+
+  private static createMatchElem(text: string): HTMLSpanElement {
+    const span = document.createElement("span");
+    span.className = CLASS_FIND_MATCH;
+    span.textContent = text;
+    return span;
+  }
+
+  /* === Helpers === */
+
+  private toggleClass(elem: HTMLElement, className: string, condition: boolean) {
+    if (condition) {
+      elem.classList.add(className);
+    } else {
+      elem.classList.remove(className);
+    }
+  }
+}

--- a/web/global.d.ts
+++ b/web/global.d.ts
@@ -56,6 +56,8 @@ declare global {
     id: number;
     hash: string;
     srcElem: HTMLElement | null;
+    compareWithHash: string | null;
+    compareWithSrcElem: HTMLElement | null;
     commitDetails: GG.GitCommitDetails | null;
     fileTree: GitFolder | null;
   }
@@ -100,6 +102,14 @@ declare global {
 
   type AvatarImageCollection = { [email: string]: string };
 
+  interface FindWidgetState {
+    text: string;
+    currentHash: string | null;
+    visible: boolean;
+    caseSensitive: boolean;
+    regex: boolean;
+  }
+
   interface WebViewState {
     gitRepos: GG.GitRepoSet;
     gitBranches: string[];
@@ -113,6 +123,7 @@ declare global {
     maxCommits: number;
     showRemoteBranches: boolean;
     expandedCommit: ExpandedCommit | null;
+    findWidgetState: FindWidgetState | null;
   }
 }
 

--- a/web/messageHandler.ts
+++ b/web/messageHandler.ts
@@ -1,0 +1,138 @@
+import type {
+  GitCommitDetails,
+  GitCommitNode,
+  GitFileChange,
+  GitRepoSet,
+  ResponseMessage
+} from "../src/types";
+import { showErrorDialog } from "./dialogs";
+import { generateGitFileTree } from "./fileTree";
+import { refreshGraphOrDisplayError } from "./utils";
+
+export interface GitGraphViewAPI {
+  hideCommitDetails(): void;
+  showCommitDetails(commitDetails: GitCommitDetails, fileTree: GitFolder): void;
+  showCompareResult(fileChanges: GitFileChange[], fromHash: string, toHash: string): void;
+  loadAvatar(email: string, image: string): void;
+  loadBranches(branches: string[], head: string | null, hard: boolean, isRepo: boolean): void;
+  loadCommits(
+    commits: GitCommitNode[],
+    head: string | null,
+    moreAvailable: boolean,
+    hard: boolean
+  ): void;
+  loadRepos(repos: GitRepoSet, lastActiveRepo: string | null): void;
+  refresh(hard: boolean): void;
+}
+
+export function handleMessage(msg: ResponseMessage, gitGraph: GitGraphViewAPI): void {
+  switch (msg.command) {
+    case "addTag":
+      refreshOrError(gitGraph, msg.status, "Unable to Add Tag");
+      break;
+    case "applyStash":
+      refreshOrError(gitGraph, msg.status, "Unable to Apply Stash");
+      break;
+    case "branchFromStash":
+      refreshOrError(gitGraph, msg.status, "Unable to Create Branch from Stash");
+      break;
+    case "checkoutBranch":
+      refreshOrError(gitGraph, msg.status, "Unable to Checkout Branch");
+      break;
+    case "checkoutCommit":
+      refreshOrError(gitGraph, msg.status, "Unable to Checkout Commit");
+      break;
+    case "cherrypickCommit":
+      refreshOrError(gitGraph, msg.status, "Unable to Cherry Pick Commit");
+      break;
+    case "cleanUntrackedFiles":
+      refreshOrError(gitGraph, msg.status, "Unable to Clean Untracked Files");
+      break;
+    case "commitDetails":
+      if (msg.commitDetails === null) {
+        gitGraph.hideCommitDetails();
+        showErrorDialog("Unable to load commit details", null, null);
+      } else {
+        gitGraph.showCommitDetails(
+          msg.commitDetails,
+          generateGitFileTree(msg.commitDetails.fileChanges)
+        );
+      }
+      break;
+    case "compareCommits":
+      if (msg.fileChanges === null) {
+        showErrorDialog("Unable to load commit comparison", null, null);
+      } else {
+        gitGraph.showCompareResult(msg.fileChanges, msg.fromHash, msg.toHash);
+      }
+      break;
+    case "copyToClipboard":
+      if (msg.success === false)
+        showErrorDialog(`Unable to Copy ${msg.type} to Clipboard`, null, null);
+      break;
+    case "createBranch":
+      refreshOrError(gitGraph, msg.status, "Unable to Create Branch");
+      break;
+    case "deleteBranch":
+      refreshOrError(gitGraph, msg.status, "Unable to Delete Branch");
+      break;
+    case "deleteTag":
+      refreshOrError(gitGraph, msg.status, "Unable to Delete Tag");
+      break;
+    case "dropStash":
+      refreshOrError(gitGraph, msg.status, "Unable to Drop Stash");
+      break;
+    case "fetch":
+      refreshOrError(gitGraph, msg.status, "Unable to Fetch");
+      break;
+    case "fetchAvatar":
+      gitGraph.loadAvatar(msg.email, msg.image);
+      break;
+    case "loadBranches":
+      gitGraph.loadBranches(msg.branches, msg.head, msg.hard, msg.isRepo);
+      break;
+    case "loadCommits":
+      gitGraph.loadCommits(msg.commits, msg.head, msg.moreCommitsAvailable, msg.hard);
+      break;
+    case "loadRepos":
+      gitGraph.loadRepos(msg.repos, msg.lastActiveRepo);
+      break;
+    case "mergeBranch":
+      refreshOrError(gitGraph, msg.status, "Unable to Merge Branch");
+      break;
+    case "mergeCommit":
+      refreshOrError(gitGraph, msg.status, "Unable to Merge Commit");
+      break;
+    case "popStash":
+      refreshOrError(gitGraph, msg.status, "Unable to Pop Stash");
+      break;
+    case "pushStash":
+      refreshOrError(gitGraph, msg.status, "Unable to Stash Changes");
+      break;
+    case "pushTag":
+      refreshOrError(gitGraph, msg.status, "Unable to Push Tag");
+      break;
+    case "renameBranch":
+      refreshOrError(gitGraph, msg.status, "Unable to Rename Branch");
+      break;
+    case "refresh":
+      gitGraph.refresh(false);
+      break;
+    case "resetToCommit":
+      refreshOrError(gitGraph, msg.status, "Unable to Reset to Commit");
+      break;
+    case "resetUncommitted":
+      refreshOrError(gitGraph, msg.status, "Unable to Reset Uncommitted Changes");
+      break;
+    case "revertCommit":
+      refreshOrError(gitGraph, msg.status, "Unable to Revert Commit");
+      break;
+    case "viewDiff":
+      if (msg.success === false) showErrorDialog("Unable to view diff of file", null, null);
+      break;
+  }
+}
+
+function refreshOrError(gitGraph: GitGraphViewAPI, status: string | null, errorMessage: string) {
+  refreshGraphOrDisplayError(status, errorMessage, () => gitGraph.refresh(true), showErrorDialog);
+}

--- a/web/refMenu.ts
+++ b/web/refMenu.ts
@@ -1,0 +1,167 @@
+import {
+  showActionRunningDialog,
+  showCheckboxDialog,
+  showConfirmationDialog,
+  showRefInputDialog
+} from "./dialogs";
+import { ELLIPSIS, escapeHtml, sendMessage } from "./utils";
+
+export function buildRefContextMenuItems(
+  repo: string,
+  refName: string,
+  sourceElem: HTMLElement,
+  isRemoteCombined: boolean,
+  gitBranchHead: string | null
+): ContextMenuElement[] {
+  let menu: ContextMenuElement[];
+  let copyType: string;
+  if (sourceElem.classList.contains("tag")) {
+    menu = [
+      {
+        title: `Delete Tag${ELLIPSIS}`,
+        onClick: () => {
+          showConfirmationDialog(
+            `Are you sure you want to delete the tag <b><i>${escapeHtml(refName)}</i></b>?`,
+            () => {
+              sendMessage({ command: "deleteTag", repo: repo, tagName: refName });
+            },
+            null
+          );
+        }
+      },
+      {
+        title: `Push Tag${ELLIPSIS}`,
+        onClick: () => {
+          showConfirmationDialog(
+            `Are you sure you want to push the tag <b><i>${escapeHtml(refName)}</i></b>?`,
+            () => {
+              sendMessage({ command: "pushTag", repo: repo, tagName: refName });
+              showActionRunningDialog("Pushing Tag");
+            },
+            null
+          );
+        }
+      }
+    ];
+    copyType = "Tag Name";
+  } else if (isRemoteCombined || sourceElem.classList.contains("remote")) {
+    menu = [
+      {
+        title: `Checkout Branch${ELLIPSIS}`,
+        onClick: () => checkoutBranchAction(repo, sourceElem, refName, isRemoteCombined)
+      }
+    ];
+    copyType = "Branch Name";
+  } else {
+    menu = [];
+    if (gitBranchHead !== refName) {
+      menu.push({
+        title: "Checkout Branch",
+        onClick: () => checkoutBranchAction(repo, sourceElem, refName)
+      });
+    }
+    menu.push({
+      title: `Rename Branch${ELLIPSIS}`,
+      onClick: () => {
+        showRefInputDialog(
+          `Enter the new name for branch <b><i>${escapeHtml(refName)}</i></b>:`,
+          refName,
+          "Rename Branch",
+          (newName) => {
+            sendMessage({
+              command: "renameBranch",
+              repo: repo,
+              oldName: refName,
+              newName: newName
+            });
+          },
+          null
+        );
+      }
+    });
+    if (gitBranchHead !== refName) {
+      menu.push(
+        {
+          title: `Delete Branch${ELLIPSIS}`,
+          onClick: () => {
+            showCheckboxDialog(
+              `Are you sure you want to delete the branch <b><i>${escapeHtml(refName)}</i></b>?`,
+              "Force Delete",
+              false,
+              "Delete Branch",
+              (forceDelete) => {
+                sendMessage({
+                  command: "deleteBranch",
+                  repo: repo,
+                  branchName: refName,
+                  forceDelete: forceDelete
+                });
+              },
+              null
+            );
+          }
+        },
+        {
+          title: `Merge into current branch${ELLIPSIS}`,
+          onClick: () => {
+            showCheckboxDialog(
+              `Are you sure you want to merge branch <b><i>${escapeHtml(refName)}</i></b> into the current branch?`,
+              "Create a new commit even if fast-forward is possible",
+              true,
+              "Yes, merge",
+              (createNewCommit) => {
+                sendMessage({
+                  command: "mergeBranch",
+                  repo: repo,
+                  branchName: refName,
+                  createNewCommit: createNewCommit
+                });
+              },
+              null
+            );
+          }
+        }
+      );
+    }
+    copyType = "Branch Name";
+  }
+  menu.push(null, {
+    title: `Copy ${copyType} to Clipboard`,
+    onClick: () => {
+      sendMessage({ command: "copyToClipboard", type: copyType, data: refName });
+    }
+  });
+  return menu;
+}
+
+export function checkoutBranchAction(
+  repo: string,
+  sourceElem: HTMLElement,
+  refName: string,
+  isRemoteCombined?: boolean
+) {
+  if (!isRemoteCombined && sourceElem.classList.contains("head")) {
+    sendMessage({
+      command: "checkoutBranch",
+      repo: repo,
+      branchName: refName,
+      remoteBranch: null
+    });
+  } else if (isRemoteCombined || sourceElem.classList.contains("remote")) {
+    let refNameComps = refName.split("/");
+    showRefInputDialog(
+      `Enter the name of the new branch you would like to create when checking out <b><i>${escapeHtml(refName)}</i></b>:`,
+      refNameComps[refNameComps.length - 1],
+      "Checkout Branch",
+      (newBranch) => {
+        sendMessage({
+          command: "checkoutBranch",
+          repo: repo,
+          branchName: newBranch,
+          remoteBranch: refName
+        });
+      },
+      null
+    );
+  }
+}

--- a/web/stashMenu.ts
+++ b/web/stashMenu.ts
@@ -1,0 +1,108 @@
+import { showCheckboxDialog, showConfirmationDialog, showRefInputDialog } from "./dialogs";
+import { ELLIPSIS, escapeHtml, sendMessage } from "./utils";
+
+export function buildStashContextMenuItems(
+  repo: string,
+  hash: string,
+  selector: string,
+  sourceElem: HTMLElement
+): ContextMenuElement[] {
+  return [
+    {
+      title: `Apply Stash${ELLIPSIS}`,
+      onClick: () => {
+        showCheckboxDialog(
+          `Are you sure you want to apply <b><i>${escapeHtml(selector)}</i></b>?`,
+          "Reinstate Index",
+          false,
+          "Yes, apply stash",
+          (reinstateIndex) => {
+            sendMessage({
+              command: "applyStash",
+              repo: repo,
+              selector: selector,
+              reinstateIndex: reinstateIndex
+            });
+          },
+          sourceElem
+        );
+      }
+    },
+    {
+      title: `Create Branch from Stash${ELLIPSIS}`,
+      onClick: () => {
+        showRefInputDialog(
+          `Enter the name of the branch you would like to create from <b><i>${escapeHtml(selector)}</i></b>:`,
+          "",
+          "Create Branch",
+          (name) => {
+            sendMessage({
+              command: "branchFromStash",
+              repo: repo,
+              branchName: name,
+              selector: selector
+            });
+          },
+          sourceElem
+        );
+      }
+    },
+    {
+      title: `Pop Stash${ELLIPSIS}`,
+      onClick: () => {
+        showCheckboxDialog(
+          `Are you sure you want to pop <b><i>${escapeHtml(selector)}</i></b>? This will remove the stash entry.`,
+          "Reinstate Index",
+          false,
+          "Yes, pop stash",
+          (reinstateIndex) => {
+            sendMessage({
+              command: "popStash",
+              repo: repo,
+              selector: selector,
+              reinstateIndex: reinstateIndex
+            });
+          },
+          sourceElem
+        );
+      }
+    },
+    {
+      title: `Drop Stash${ELLIPSIS}`,
+      onClick: () => {
+        showConfirmationDialog(
+          `Are you sure you want to drop <b><i>${escapeHtml(selector)}</i></b>? This cannot be undone.`,
+          () => {
+            sendMessage({
+              command: "dropStash",
+              repo: repo,
+              selector: selector
+            });
+          },
+          sourceElem
+        );
+      }
+    },
+    null,
+    {
+      title: "Copy Stash Name to Clipboard",
+      onClick: () => {
+        sendMessage({
+          command: "copyToClipboard",
+          type: "Stash Name",
+          data: selector
+        });
+      }
+    },
+    {
+      title: "Copy Stash Hash to Clipboard",
+      onClick: () => {
+        sendMessage({
+          command: "copyToClipboard",
+          type: "Stash Hash",
+          data: hash
+        });
+      }
+    }
+  ];
+}

--- a/web/uncommittedMenu.ts
+++ b/web/uncommittedMenu.ts
@@ -1,0 +1,93 @@
+import {
+  showCheckboxDialog,
+  showConfirmationDialog,
+  showFormDialog,
+  showSelectDialog
+} from "./dialogs";
+import { ELLIPSIS, sendMessage } from "./utils";
+
+export function buildUncommittedContextMenuItems(
+  repo: string,
+  sourceElem: HTMLElement
+): ContextMenuElement[] {
+  return [
+    {
+      title: `Stash uncommitted changes${ELLIPSIS}`,
+      onClick: () => {
+        showFormDialog(
+          "Stash uncommitted changes:",
+          [
+            {
+              type: "text" as const,
+              name: "Message: ",
+              default: "",
+              placeholder: "Optional"
+            },
+            {
+              type: "checkbox" as const,
+              name: "Include Untracked",
+              value: false
+            }
+          ],
+          "Stash Changes",
+          (values) => {
+            sendMessage({
+              command: "pushStash",
+              repo: repo,
+              message: values[0],
+              includeUntracked: values[1] === "checked"
+            });
+          },
+          sourceElem
+        );
+      }
+    },
+    {
+      title: `Reset uncommitted changes${ELLIPSIS}`,
+      onClick: () => {
+        showSelectDialog(
+          "Select the mode to reset uncommitted changes:",
+          "mixed",
+          [
+            { name: "Mixed - Keep changes in working directory", value: "mixed" },
+            { name: "Hard - Discard all changes", value: "hard" }
+          ],
+          "Reset",
+          (mode) => {
+            showConfirmationDialog(
+              `Are you sure you want to reset uncommitted changes with <b>${mode}</b> mode?${mode === "hard" ? " This will discard all uncommitted changes and cannot be undone." : ""}`,
+              () => {
+                sendMessage({
+                  command: "resetUncommitted",
+                  repo: repo,
+                  mode: mode
+                });
+              },
+              sourceElem
+            );
+          },
+          sourceElem
+        );
+      }
+    },
+    {
+      title: `Clean untracked files${ELLIPSIS}`,
+      onClick: () => {
+        showCheckboxDialog(
+          "Are you sure you want to clean untracked files? This cannot be undone.",
+          "Clean untracked directories",
+          false,
+          "Clean",
+          (directories) => {
+            sendMessage({
+              command: "cleanUntrackedFiles",
+              repo: repo,
+              directories: directories
+            });
+          },
+          sourceElem
+        );
+      }
+    }
+  ];
+}

--- a/web/utils.ts
+++ b/web/utils.ts
@@ -1,9 +1,15 @@
 import * as GG from "../src/types";
+import { UNCOMMITTED_CHANGES_HASH } from "../src/types";
+export { UNCOMMITTED_CHANGES_HASH };
 
 const vscode = acquireVsCodeApi();
 export { vscode };
 
 export const svgIcons = {
+  current:
+    '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="16" viewBox="0 0 14 16"><path d="M 8.5793251,3.9709273 C 5.7393555,3.9722573 3.3857785,6.1732278 3.1943505,9.0067388 H 4.7680416 C 4.9548119,7.0413876 6.6051194,5.5401404 8.5793251,5.5397007 10.693557,5.5401531 12.407367,7.2539644 12.407817,9.3681961 12.408725,11.483388 10.694517,13.198699 8.5793251,13.199151 6.603404,13.198471 4.9524361,11.694493 4.7680416,9.727194 H 3.1943505 c 0.188959,2.835453 2.5432332,5.039225 5.3849746,5.04073 2.9812129,-0.0014 5.3972349,-2.418515 5.3972659,-5.3997279 -0.0014,-2.980253 -2.417013,-5.3958792 -5.3972659,-5.3972688 z m 0,3.1375466 c -0.8665744,3.13e-5 -1.655905,0.5013756 -2.0285866,1.2884596 0.4371757,0.1661687 0.9045642,0.3506253 1.2589529,0.4991552 0.3227657,0.135276 0.9442147,0.3573058 0.9442147,0.4745662 0,0.1172591 -0.621449,0.3368301 -0.9442147,0.4721071 -0.3543887,0.14853 -0.8217772,0.332987 -1.2589529,0.499155 0.3726816,0.787084 1.1620121,1.288429 2.0285866,1.28846 1.2398219,-0.0012 2.2444269,-1.012386 2.2449659,-2.2597221 8.1e-4,-1.2482965 -1.0041896,-2.2610032 -2.2449659,-2.262181 z M 5.579476,8.4313581 c -0.052649,0.00816 -0.07526,0.1152306 0,0.159828 L 6.4769718,9.1223068 H 2.3625859 L 1.8806431,8.3507087 H 0.01849445 l 0.752421,1.0199462 -0.752421,1.0199461 H 1.8806431 L 2.3650449,9.6165442 H 2.6825055 6.4794307 L 5.579476,10.150124 c -0.07526,0.0446 -0.052649,0.15167 0,0.159828 0.2360449,0.03657 1.406845,-0.369239 2.0900586,-0.614723 0.2586305,-0.092928 0.7573385,-0.244023 0.7573385,-0.3245741 0,-0.080552 -0.498708,-0.2316459 -0.7573385,-0.3245738 C 6.986321,8.8005973 5.815521,8.3947939 5.579476,8.4313581 Z"/></svg>',
+  refresh:
+    '<svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M 8.244,15.672 C 11.441,15.558 14.868,13.024 14.828,8.55 14.773,6.644 13.911,4.852 12.456,3.619 l -1.648,1.198 c 1.265,0.861 2.037,2.279 2.074,3.809 0.016,2.25 -1.808,5.025 -4.707,5.077 -2.898,0.052 -4.933,-2.08 -5.047,-4.671 C 3.07,6.705 4.635,4.651 6.893,4.088 l 0.041,1.866 3.853,-3.126 -3.978,-2.772 0.032,2.077 c -3.294,0.616 -5.755,3.541 -5.667,6.982 -3.88e-4,4.233 3.873,6.67 7.07,6.557 z"/></svg>',
   alert:
     '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"/></svg>',
   branch:
@@ -18,7 +24,18 @@ export const svgIcons = {
     '<svg xmlns="http://www.w3.org/2000/svg" class="openFolderIcon" viewBox="0 0 30 30"><path d="M 5 4 C 3.895 4 3 4.895 3 6 L 3 9 L 3 11 L 22 11 L 27 11 L 27 8 C 27 6.895 26.105 6 25 6 L 12.199219 6 L 11.582031 4.9707031 C 11.221031 4.3687031 10.570187 4 9.8671875 4 L 5 4 z M 2.5019531 13 C 1.4929531 13 0.77040625 13.977406 1.0664062 14.941406 L 4.0351562 24.587891 C 4.2941563 25.426891 5.0692656 26 5.9472656 26 L 15 26 L 24.052734 26 C 24.930734 26 25.705844 25.426891 25.964844 24.587891 L 28.933594 14.941406 C 29.229594 13.977406 28.507047 13 27.498047 13 L 15 13 L 2.5019531 13 z"/></svg>',
   closedFolder:
     '<svg xmlns="http://www.w3.org/2000/svg" class="closedFolderIcon" viewBox="0 0 30 30"><path d="M 4 3 C 2.895 3 2 3.895 2 5 L 2 8 L 13 8 L 28 8 L 28 7 C 28 5.895 27.105 5 26 5 L 11.199219 5 L 10.582031 3.9707031 C 10.221031 3.3687031 9.5701875 3 8.8671875 3 L 4 3 z M 3 10 C 2.448 10 2 10.448 2 11 L 2 23 C 2 24.105 2.895 25 4 25 L 26 25 C 27.105 25 28 24.105 28 23 L 28 11 C 28 10.448 27.552 10 27 10 L 3 10 z"/></svg>',
-  file: '<svg xmlns="http://www.w3.org/2000/svg" class="fileIcon" viewBox="0 0 30 30"><path d="M24.707,8.793l-6.5-6.5C18.019,2.105,17.765,2,17.5,2H7C5.895,2,5,2.895,5,4v22c0,1.105,0.895,2,2,2h16c1.105,0,2-0.895,2-2 V9.5C25,9.235,24.895,8.981,24.707,8.793z M18,10c-0.552,0-1-0.448-1-1V3.904L23.096,10H18z"/></svg>'
+  file: '<svg xmlns="http://www.w3.org/2000/svg" class="fileIcon" viewBox="0 0 30 30"><path d="M24.707,8.793l-6.5-6.5C18.019,2.105,17.765,2,17.5,2H7C5.895,2,5,2.895,5,4v22c0,1.105,0.895,2,2,2h16c1.105,0,2-0.895,2-2 V9.5C25,9.235,24.895,8.981,24.707,8.793z M18,10c-0.552,0-1-0.448-1-1V3.904L23.096,10H18z"/></svg>',
+  fetch:
+    '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M7.47 10.78a.749.749 0 0 0 1.06 0l3.75-3.75a.749.749 0 1 0-1.06-1.06L8.75 8.44V1.75a.75.75 0 0 0-1.5 0v6.69L4.78 5.97a.749.749 0 1 0-1.06 1.06l3.75 3.75zM3.75 13a.75.75 0 0 0 0 1.5h8.5a.75.75 0 0 0 0-1.5h-8.5z"/></svg>',
+  stash:
+    '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M2.8 2.06A1.75 1.75 0 0 1 4.41 1h7.18c.7 0 1.333.417 1.61 1.06l2.74 6.395a.75.75 0 0 1 .06.295v4.5A1.75 1.75 0 0 1 14.25 15H1.75A1.75 1.75 0 0 1 0 13.25v-4.5a.75.75 0 0 1 .06-.295L2.8 2.06zM4.41 2.5a.25.25 0 0 0-.23.152L1.68 8H4.75a.75.75 0 0 1 .75.75 2.5 2.5 0 0 0 5 0 .75.75 0 0 1 .75-.75h3.07L11.82 2.652a.25.25 0 0 0-.23-.152H4.41zM1.5 9.5v3.75c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25V9.5h-2.9a4 4 0 0 1-7.7 0H1.5z"/></svg>',
+  search:
+    '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M10.68 11.74a6 6 0 1 1 1.06-1.06l3.04 3.04-1.06 1.06-3.04-3.04zM11.5 7a4.5 4.5 0 1 0-9 0 4.5 4.5 0 0 0 9 0z"/></svg>',
+  arrowUp:
+    '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8 4.94L3.47 9.47l.94.94L8 6.82l3.59 3.59.94-.94L8 4.94z"/></svg>',
+  arrowDown:
+    '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8 11.06l-4.53-4.53.94-.94L8 9.18l3.59-3.59.94.94L8 11.06z"/></svg>',
+  cdv: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8 5.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5zM4.5 8a3.5 3.5 0 1 1 7 0 3.5 3.5 0 0 1-7 0zM8 4c-2.8 0-5.2 1.6-6.7 4 1.5 2.4 3.9 4 6.7 4s5.2-1.6 6.7-4C13.2 5.6 10.8 4 8 4z"/></svg>'
 };
 export const months = [
   "Jan",
@@ -84,9 +101,41 @@ export function insertAfter(newNode: HTMLElement, referenceNode: HTMLElement) {
   referenceNode.parentNode!.insertBefore(newNode, referenceNode.nextSibling);
 }
 
+export function buildCommitRowAttributes(hash: string, stash: GG.GitCommitStash | null): string {
+  if (hash === UNCOMMITTED_CHANGES_HASH) {
+    return `class="unsavedChanges" data-hash="${UNCOMMITTED_CHANGES_HASH}"`;
+  } else if (stash !== null) {
+    return `class="commit stash" data-hash="${hash}"`;
+  } else {
+    return `class="commit" data-hash="${hash}"`;
+  }
+}
+
+export function buildStashSelectorDisplay(selector: string): string {
+  return selector.substring("stash".length);
+}
+
 export function sendMessage(msg: GG.RequestMessage) {
   vscode.postMessage(msg);
 }
+
+export function refreshGraphOrDisplayError(
+  status: GG.GitCommandStatus,
+  errorMessage: string,
+  onRefresh: () => void,
+  showError: (message: string, reason: string, sourceElem: null) => void
+) {
+  if (status === null) {
+    onRefresh();
+  } else {
+    showError(errorMessage, status, null);
+  }
+}
 export function getVSCodeStyle(name: string) {
   return document.documentElement.style.getPropertyValue(name);
+}
+
+const ABBREV_COMMIT_LENGTH = 8;
+export function abbrevCommit(commitHash: string) {
+  return commitHash.substring(0, ABBREV_COMMIT_LENGTH);
 }


### PR DESCRIPTION
# Issue

- N/A

# 背景・目的

Git Keizu のメニューバー周辺の操作性向上を目的に、2つの機能群を一括で実装した。

1. **メニューバー強化**（[001-menu-bar]）: スクロール時もメニューバーと列タイトルが固定表示されるよう scroll container を導入し、スタッシュのグラフ表示・右クリックメニュー・フェッチボタン・Uncommitted Changes の右クリックメニューを追加した。
2. **検索・比較機能**（[002-add-menu]）: FindWidget によるコミット検索（正規表現・大小文字区別対応）と、Ctrl/Cmd+クリックによる2点間コミット比較機能を追加した。

# 変更内容

## バックエンド（`src/`）

- `src/types.ts`: スタッシュ型（`GitStash`, `GitStashEntry`）、未コミット詳細型、コミット比較リクエスト型を追加。`ResetMode` 名前付き定数を追加
- `src/dataSource.ts`: `getStashes`、`applyStash`、`popStash`、`dropStash`、`stashBranch`、`stashPush`、`fetch`、`getUncommittedDetails`、`compareCommits` を追加
- `src/gitGraphView.ts`: 上記に対応するメッセージルーティングを追加。HTML テンプレートにスクロールコンテナとツールバーボタンを追加

## フロントエンド（`web/`）

- `web/commitMenu.ts`（新規）: コミット行の右クリックメニュービルダーを分離
- `web/refMenu.ts`（新規）: ブランチ/タグ/リモートラベルの右クリックメニュービルダーを分離
- `web/stashMenu.ts`（新規）: スタッシュ行の右クリックメニュービルダー（Apply/Pop/Drop/Branch/Copy）を追加
- `web/uncommittedMenu.ts`（新規）: Uncommitted Changes 行の右クリックメニュービルダー（Stash/Reset/Clean）を追加
- `web/messageHandler.ts`（新規）: バックエンドからのレスポンスハンドラーを分離
- `web/findWidget.ts`（新規）: FindWidget コンポーネント（検索入力・Aa/.* トグル・N of M カウンター・前/次ナビゲーション・状態永続化）
- `web/graph.ts`: スタッシュコミットを二重円（ring）スタイルで描画
- `web/main.ts`: スクロールコンテナ対応、比較モード（Ctrl/Cmd+クリック）、スタッシュ行描画を追加。コンテキストメニュー・メッセージハンドラーを各モジュールに分離（1667→849行）
- `web/utils.ts`: `scrollToCommit` ユーティリティを追加
- `web/global.d.ts`: FindWidget・比較モード関連のグローバル型定義を追加

## スタイル

- `media/main.css`: スクロールコンテナ用 sticky レイアウト、FindWidget スタイル、スタッシュ行スタイル、ツールバーアイコンボタンスタイルを追加

## テスト・ドキュメント

- `tests/src/`: dataSource・gitGraphView・types のユニットテストを新規追加（計 2,275 行）
- `tests/web/`: findWidget・graph・main のテストを新規追加・更新（計 2,353 行）
- `.aidd/steering/`: プロジェクトのAI開発ステアリングドキュメントを追加
- `docs/testing/perspectives/`: テスト観点表を追加

# 技術的な詳細

- **モジュール分割**: `web/main.ts` が肥大化していたため、コンテキストメニュービルダー（4ファイル）とメッセージハンドラー（1ファイル）を分離。単一責任の原則に沿った構造とした
- **スクロールコンテナ**: メニューバー固定表示は CSS の sticky ではなく、`#commitTable` を overflow スクロール対象とし、ヘッダー行を外部に固定するアプローチを採用
- **スタッシュ表示**: `git stash list` で取得したスタッシュを、`baseHash` を使って親コミットの直下に挿入してグラフ描画。二重円（ring）スタイルで通常コミットと視覚的に区別
- **比較モード**: 最初のコミット選択後、Ctrl/Cmd+クリックで2番目を選択し `compareCommits` リクエストを送信。再クリックで解除
- **セキュリティ**: 全Gitコマンドは既存の `spawn()` ベースの `runGitCommandSpawn`/`spawnGit` 経由。ブランチ名・コミットハッシュのバリデーションは既存のバリデーター関数を使用

# 影響範囲・互換性

- 破壊的変更（Breaking）: ➖
- DBマイグレーション: ➖
- 環境変数の追加/変更: ➖
- 外部API/スキーマ変更: ➖
- 認証/認可ロジック: ➖
- パフォーマンス影響: ➖（スタッシュ取得は既存リフレッシュ時に追加実行）

# 動作確認手順

1. 拡張機能をビルドして VS Code で起動（`pnpm run compile`）
2. **Sticky Header**: コミット数の多いリポジトリで下方向にスクロールし、メニューバーと列タイトルが固定表示されることを確認
3. **スタッシュ表示**: `git stash push -m "test"` でスタッシュを作成し、コミットグラフに二重円スタイルで表示されることを確認
4. **スタッシュメニュー**: スタッシュ行を右クリックして Apply/Pop/Drop/Create Branch/Copy の各操作を確認
5. **Uncommitted Changes メニュー**: 変更ファイルがある状態で Uncommitted Changes 行を右クリックし、Stash/Reset/Clean を確認
6. **Fetch ボタン**: ツールバーの Fetch アイコンをクリックして `git fetch --all` が実行されることを確認
7. **FindWidget**: 検索ボタン or Ctrl+F でウィジェットが表示され、コミットメッセージ・著者名・ハッシュでの検索・ハイライト・ナビゲーションを確認
8. **比較モード**: コミットを1つ選択した状態で別のコミットを Ctrl+クリックし、2点間差分ファイル一覧が表示されることを確認

# テスト

- 自動テスト: `pnpm run test:ci` — 211 tests passed（8 test files）
  - `tests/src/dataSource.test.ts`: stash操作・fetch・compareCommits の正常系/異常系
  - `tests/src/gitGraphView.test.ts`: メッセージルーティングのテスト
  - `tests/src/types.test.ts`: 型・定数のテスト
  - `tests/web/findWidget.test.ts`: FindWidget の表示・検索・ナビゲーション・状態永続化
  - `tests/web/graph.test.ts`: stash ring スタイルの描画テスト
  - `tests/web/main.test.ts`: 比較モード・スタッシュ行表示・Uncommitted Changes のテスト
  - `tests/web/utils.test.ts`: scrollToCommit のテスト

# リスク・懸念点・ロールバック

- **リスク**: `web/main.ts` のモジュール分割による参照漏れがないか、統合テストで検証が必要
- **ロールバック**: `feat/menu` ブランチを main にマージしないことで影響なし。マージ後は `git revert` を利用

# レビューポイント

- `src/dataSource.ts`: 新規 git コマンド（stash/fetch/compareCommits）の spawn 呼び出しとエラーハンドリングの妥当性
- `web/stashMenu.ts` / `web/uncommittedMenu.ts`: 破壊的操作（Drop/Reset/Clean）前の確認ダイアログが全ケースで呼ばれているか
- `web/findWidget.ts`: 状態永続化（viewState）のキー名と保存タイミング
- `web/main.ts`: 比較モードの状態管理（`comparedCommit` の設定・解除・表示切り替え）

# マージ前チェックリスト

## セキュリティ
- ✅ シークレットのハードコード無し／環境変数で管理
- ✅ 入力バリデーション: ブランチ名・コミットハッシュは既存バリデーター関数を使用、stashSelector はハッシュ検証済み
- ➖ 権限/CSRF/レート制限（VS Code 拡張機能のため対象外）

## ドキュメント
- ✅ CLAUDE.md / README への影響なし（新機能追加・設定項目追加なし）
- ➖ .env.example 更新（環境変数追加なし）
- ➖ スクリーンショット（UI変更あるが動作確認手順で代替）