### PR TITLE
feat: SCM統合、キーボードショートカット、自動読み込み、ドロップダウン幅制御を実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@
 
 [![](https://img.shields.io/github/license/numlia/git-keizu)](https://github.com/numlia/git-keizu?tab=MIT-1-ov-file)
 [![GitHub release](https://img.shields.io/github/v/release/numlia/git-keizu)](https://github.com/numlia/git-keizu/releases)
-[![vscode downloads](https://img.shields.io/visual-studio-marketplace/d/numlia-vs.git-keizu?label=download)](https://marketplace.visualstudio.com/items?itemName=numlia-vs.git-keizu)
 [![vscode installs](https://img.shields.io/visual-studio-marketplace/i/numlia-vs.git-keizu?label=install)](https://marketplace.visualstudio.com/items?itemName=numlia-vs.git-keizu)
 [![open-vsx downloads](https://img.shields.io/open-vsx/dt/numlia-vs/git-keizu?label=open-vsx)](https://open-vsx.org/extension/numlia-vs/git-keizu)
 
 A fork of [neo-git-graph](https://github.com/asispts/neo-git-graph) by asispts, which is itself a fork of [Git Graph](https://github.com/mhutchie/vscode-git-graph) by mhutchie, based on commit [4af8583](https://github.com/mhutchie/vscode-git-graph/commit/4af8583a42082b2c230d2c0187d4eaff4b69c665) (May 9, 2019) — the last version released under the MIT license.
+
+Git Keizu is a personal take on a git history viewer — shaped around the features I actually use every day. The goal is a focused, dependable tool, not the most feature-complete one.
 
 ## Features
 

--- a/docs/testing/perspectives/INDEX.md
+++ b/docs/testing/perspectives/INDEX.md
@@ -1,23 +1,26 @@
 # テスト観点表インデックス
 
-> Auto-generated: 2026-02-26T00:00:00+09:00
-> Total files: 11
-> Total sections: 41
-> Total cases: 236
+> Auto-generated: 2026-02-27T00:00:00+09:00
+> Total files: 14
+> Total sections: 59
+> Total cases: 300
 
 ## ソースファイル → 観点表（正引き）
 
 | Source File           | Perspectives File          | Sections | Cases | Last Updated |
 | --------------------- | -------------------------- | -------- | ----- | ------------ |
+| src/config.ts         | src/config-test.md         | 4        | 21    | 2026-02-27   |
 | src/dataSource.ts     | src/dataSource-test.md     | 10       | 77    | 2026-02-25   |
-| src/gitGraphView.ts   | src/gitGraphView-test.md   | 5        | 14    | 2026-02-25   |
+| src/gitGraphView.ts   | src/gitGraphView-test.md   | 7        | 20    | 2026-02-27   |
+| src/repoManager.ts    | src/repoManager-test.md    | 1        | 3     | 2026-02-27   |
 | src/types.ts          | src/types-test.md          | 1        | 7     | 2026-02-25   |
 | web/contextMenu.ts    | web/contextMenu-test.md    | 1        | 7     | 2026-02-25   |
 | web/dialogs.ts        | web/dialogs-test.md        | 2        | 11    | 2026-02-25   |
+| web/dropdown.ts       | web/dropdown-test.md       | 5        | 15    | 2026-02-27   |
 | web/findWidget.ts     | web/findWidget-test.md     | 7        | 32    | 2026-02-25   |
 | web/graph.ts          | web/graph-test.md          | 1        | 2     | 2026-02-25   |
-| web/main.ts           | web/main-test.md           | 9        | 64    | 2026-02-26   |
-| web/messageHandler.ts | web/messageHandler-test.md | 2        | 6     | 2026-02-26   |
+| web/main.ts           | web/main-test.md           | 14       | 100   | 2026-02-27   |
+| web/messageHandler.ts | web/messageHandler-test.md | 3        | 8     | 2026-02-27   |
 | web/refMenu.ts        | web/refMenu-test.md        | 2        | 10    | 2026-02-25   |
 | web/utils.ts          | web/utils-test.md          | 1        | 2     | 2026-02-25   |
 
@@ -29,4 +32,5 @@
 | Feature 002 (menubar-search-diff)       | src/dataSource-test.md, src/gitGraphView-test.md, web/findWidget-test.md, web/main-test.md                                                      |
 | Feature 003 (ux-fixes-and-enhancements) | src/dataSource-test.md, src/gitGraphView-test.md, web/contextMenu-test.md, web/dialogs-test.md, web/messageHandler-test.md, web/refMenu-test.md |
 | Feature 004 (webview-ux-polish)         | web/main-test.md, web/messageHandler-test.md                                                                                                    |
+| Feature 005 (webview-ux-enhancements)   | src/config-test.md, src/gitGraphView-test.md, src/repoManager-test.md, web/dropdown-test.md, web/main-test.md, web/messageHandler-test.md       |
 | test-plan (既存テスト)                  | src/dataSource-test.md                                                                                                                          |

--- a/docs/testing/perspectives/src/config-test.md
+++ b/docs/testing/perspectives/src/config-test.md
@@ -1,0 +1,68 @@
+# テスト観点表: src/config.ts
+
+> Source: `src/config.ts`
+> Generated: 2026-02-27T00:00:00+09:00
+
+## S1: parseKeybinding() ショートカット設定値パース
+
+> Origin: Feature 005 (webview-ux-enhancements) (aidd-spec-tasks-test)
+> Added: 2026-02-27
+
+**シグネチャ**: `parseKeybinding(value: string, defaultValue: string): string | null`
+**テスト対象パス**: `src/config.ts`
+
+| Case ID | Input / Precondition                                        | Perspective (Equivalence / Boundary)    | Expected Result              | Notes                       |
+| ------- | ----------------------------------------------------------- | --------------------------------------- | ---------------------------- | --------------------------- |
+| TC-001  | value="CTRL/CMD + F", default="CTRL/CMD + F"                | Equivalence - normal                    | "f" を返す                   | 正規表現マッチ → 小文字変換 |
+| TC-002  | value="CTRL/CMD + Z", default="CTRL/CMD + F"                | Equivalence - normal                    | "z" を返す                   | 末尾英字を抽出              |
+| TC-003  | value="CTRL/CMD + A", default="CTRL/CMD + F"                | Equivalence - normal                    | "a" を返す                   | 先頭英字                    |
+| TC-004  | value="UNASSIGNED", default="CTRL/CMD + F"                  | Equivalence - special value             | null を返す                  | ショートカット無効化        |
+| TC-005  | value="Ctrl+F" (不正形式), default="CTRL/CMD + F"           | Equivalence - abnormal (invalid format) | "f" を返す（デフォルト適用） | スラッシュ・スペース不足    |
+| TC-006  | value="" (空文字), default="CTRL/CMD + F"                   | Boundary - empty                        | "f" を返す（デフォルト適用） | 空入力                      |
+| TC-007  | value="ctrl/cmd + f" (小文字), default="CTRL/CMD + F"       | Equivalence - abnormal (case mismatch)  | "f" を返す（デフォルト適用） | 正規表現は大文字のみ許可    |
+| TC-008  | value="CTRL/CMD + 1" (数字), default="CTRL/CMD + F"         | Equivalence - abnormal (non-alpha)      | "f" を返す（デフォルト適用） | 英字以外は不正              |
+| TC-009  | value="CTRL/CMD + F" (余分スペース), default="CTRL/CMD + F" | Boundary - extra whitespace             | "f" を返す（デフォルト適用） | 正規表現厳密一致            |
+| TC-010  | value="CTRL/CMD + FF" (2文字), default="CTRL/CMD + F"       | Boundary - extra chars                  | "f" を返す（デフォルト適用） | 英字1文字のみ許可           |
+
+## S2: sourceCodeProviderIntegrationLocation() SCMボタン位置設定
+
+> Origin: Feature 005 (webview-ux-enhancements) (aidd-spec-tasks-test)
+> Added: 2026-02-27
+
+**シグネチャ**: `sourceCodeProviderIntegrationLocation(): string`
+**テスト対象パス**: `src/config.ts`
+
+| Case ID | Input / Precondition     | Perspective (Equivalence / Boundary) | Expected Result       | Notes            |
+| ------- | ------------------------ | ------------------------------------ | --------------------- | ---------------- |
+| TC-011  | 設定未指定（デフォルト） | Equivalence - normal (default)       | "Inline" を返す       | デフォルト値     |
+| TC-012  | 設定値="More Actions"    | Equivalence - normal                 | "More Actions" を返す | 有効な代替値     |
+| TC-013  | 設定値="Inline"          | Equivalence - normal                 | "Inline" を返す       | 明示的デフォルト |
+
+## S3: keyboardShortcut\*() キーボードショートカット設定
+
+> Origin: Feature 005 (webview-ux-enhancements) (aidd-spec-tasks-test)
+> Added: 2026-02-27
+
+**テスト対象パス**: `src/config.ts`
+
+| Case ID | Input / Precondition                          | Perspective (Equivalence / Boundary) | Expected Result | Notes                     |
+| ------- | --------------------------------------------- | ------------------------------------ | --------------- | ------------------------- |
+| TC-014  | keyboardShortcutFind() デフォルト             | Equivalence - normal                 | "f" を返す      | デフォルト "CTRL/CMD + F" |
+| TC-015  | keyboardShortcutRefresh() デフォルト          | Equivalence - normal                 | "r" を返す      | デフォルト "CTRL/CMD + R" |
+| TC-016  | keyboardShortcutScrollToHead() デフォルト     | Equivalence - normal                 | "h" を返す      | デフォルト "CTRL/CMD + H" |
+| TC-017  | keyboardShortcutScrollToStash() デフォルト    | Equivalence - normal                 | "s" を返す      | デフォルト "CTRL/CMD + S" |
+| TC-018  | keyboardShortcutFind() に "CTRL/CMD + A" 設定 | Equivalence - normal (custom)        | "a" を返す      | カスタムキー              |
+| TC-019  | keyboardShortcutFind() に "UNASSIGNED" 設定   | Equivalence - special value          | null を返す     | ショートカット無効        |
+
+## S4: loadMoreCommitsAutomatically() 自動読み込み設定
+
+> Origin: Feature 005 (webview-ux-enhancements) (aidd-spec-tasks-test)
+> Added: 2026-02-27
+
+**シグネチャ**: `loadMoreCommitsAutomatically(): boolean`
+**テスト対象パス**: `src/config.ts`
+
+| Case ID | Input / Precondition     | Perspective (Equivalence / Boundary) | Expected Result | Notes          |
+| ------- | ------------------------ | ------------------------------------ | --------------- | -------------- |
+| TC-020  | 設定未指定（デフォルト） | Equivalence - normal (default)       | true を返す     | デフォルト有効 |
+| TC-021  | 設定値=false             | Equivalence - normal                 | false を返す    | 明示的無効化   |

--- a/docs/testing/perspectives/src/gitGraphView-test.md
+++ b/docs/testing/perspectives/src/gitGraphView-test.md
@@ -63,3 +63,29 @@
 | ------- | ----------------------------------------------- | ------------------------------------ | --------------------------------------------------------- | -------------------- |
 | TC-013  | { command: "pull", repo: "..." } メッセージ受信 | Equivalence - normal                 | dataSource.pull(repo) が呼ばれ、ResponsePull が送信される | pushTag パターン準拠 |
 | TC-014  | { command: "push", repo: "..." } メッセージ受信 | Equivalence - normal                 | dataSource.push(repo) が呼ばれ、ResponsePush が送信される | pushTag パターン準拠 |
+
+## S6: createOrShow() rootUri ハンドリング
+
+> Origin: Feature 005 (webview-ux-enhancements) (aidd-spec-tasks-test)
+> Added: 2026-02-27
+
+**テスト対象パス**: `src/gitGraphView.ts`
+
+| Case ID | Input / Precondition                             | Perspective (Equivalence / Boundary)  | Expected Result                                                        | Notes          |
+| ------- | ------------------------------------------------ | ------------------------------------- | ---------------------------------------------------------------------- | -------------- |
+| TC-015  | rootUri 指定あり、パネル未作成                   | Equivalence - normal (new panel)      | viewState.lastActiveRepo が rootUri.fsPath に設定される                | 初回起動時     |
+| TC-016  | rootUri 指定あり、パネル既存、リポジトリ登録済み | Equivalence - normal (existing panel) | panel.reveal() 後に ResponseSelectRepo が送信される                    | リポジトリ切替 |
+| TC-017  | rootUri 指定あり、パネル既存、リポジトリ未登録   | Equivalence - normal (unregistered)   | registerRepoFromUri() が呼ばれ、その後 ResponseSelectRepo が送信される | 新規登録フロー |
+| TC-018  | rootUri 指定なし（コマンドパレットから実行）     | Equivalence - normal (no rootUri)     | 従来動作維持（selectRepo メッセージ送信なし）                          | 後方互換       |
+
+## S7: viewState キーバインド・自動読み込み設定の受け渡し
+
+> Origin: Feature 005 (webview-ux-enhancements) (aidd-spec-tasks-test)
+> Added: 2026-02-27
+
+**テスト対象パス**: `src/gitGraphView.ts`
+
+| Case ID | Input / Precondition         | Perspective (Equivalence / Boundary) | Expected Result                                      | Notes                |
+| ------- | ---------------------------- | ------------------------------------ | ---------------------------------------------------- | -------------------- |
+| TC-019  | getHtmlForWebview() 呼び出し | Equivalence - normal                 | viewState に keybindings オブジェクトが含まれる      | 設定パイプライン検証 |
+| TC-020  | getHtmlForWebview() 呼び出し | Equivalence - normal                 | viewState に loadMoreCommitsAutomatically が含まれる | 設定パイプライン検証 |

--- a/docs/testing/perspectives/src/repoManager-test.md
+++ b/docs/testing/perspectives/src/repoManager-test.md
@@ -1,0 +1,18 @@
+# テスト観点表: src/repoManager.ts
+
+> Source: `src/repoManager.ts`
+> Generated: 2026-02-27T00:00:00+09:00
+
+## S1: registerRepoFromUri() URI からのリポジトリ登録
+
+> Origin: Feature 005 (webview-ux-enhancements) (aidd-spec-tasks-test)
+> Added: 2026-02-27
+
+**シグネチャ**: `registerRepoFromUri(uri: vscode.Uri): Promise<void>`
+**テスト対象パス**: `src/repoManager.ts`
+
+| Case ID | Input / Precondition                          | Perspective (Equivalence / Boundary) | Expected Result                                           | Notes          |
+| ------- | --------------------------------------------- | ------------------------------------ | --------------------------------------------------------- | -------------- |
+| TC-001  | URI が既に登録済みリポジトリを指す            | Equivalence - normal (existing)      | addRepo が呼ばれない、既存状態維持                        | 重複登録防止   |
+| TC-002  | URI が未登録の有効な Git リポジトリを指す     | Equivalence - normal (new repo)      | addRepo が呼ばれ、sendRepos でビューに通知される          | 新規登録フロー |
+| TC-003  | URI が Git リポジトリでないディレクトリを指す | Equivalence - abnormal (non-git)     | isGitRepository が false を返し、登録処理がスキップされる | 事前検証       |

--- a/docs/testing/perspectives/web/dropdown-test.md
+++ b/docs/testing/perspectives/web/dropdown-test.md
@@ -1,0 +1,71 @@
+# テスト観点表: web/dropdown.ts
+
+> Source: `web/dropdown.ts`
+> Generated: 2026-02-27T00:00:00+09:00
+
+## S1: isOpen() 展開状態判定
+
+> Origin: Feature 005 (webview-ux-enhancements) (aidd-spec-tasks-test)
+> Added: 2026-02-27
+
+**シグネチャ**: `isOpen(): boolean`
+**テスト対象パス**: `web/dropdown.ts`
+
+| Case ID | Input / Precondition                 | Perspective (Equivalence / Boundary) | Expected Result | Notes        |
+| ------- | ------------------------------------ | ------------------------------------ | --------------- | ------------ |
+| TC-001  | ドロップダウン初期状態（閉じている） | Equivalence - normal (closed)        | false を返す    | 初期状態     |
+| TC-002  | ドロップダウン展開後                 | Equivalence - normal (open)          | true を返す     | open() 後    |
+| TC-003  | 展開後に close() 呼び出し            | Equivalence - normal (re-closed)     | false を返す    | 状態遷移検証 |
+
+## S2: close() パブリック化
+
+> Origin: Feature 005 (webview-ux-enhancements) (aidd-spec-tasks-test)
+> Added: 2026-02-27
+
+**シグネチャ**: `close(): void`
+**テスト対象パス**: `web/dropdown.ts`
+
+| Case ID | Input / Precondition           | Perspective (Equivalence / Boundary) | Expected Result                                 | Notes  |
+| ------- | ------------------------------ | ------------------------------------ | ----------------------------------------------- | ------ |
+| TC-004  | ドロップダウン展開中に close() | Equivalence - normal                 | ドロップダウンが非表示になり、isOpen() が false | -      |
+| TC-005  | 既に閉じている状態で close()   | Boundary - already closed            | エラーなし、isOpen() は引き続き false           | 冪等性 |
+
+## S3: escapeHtml XSS修正
+
+> Origin: Feature 005 (webview-ux-enhancements) (aidd-spec-tasks-test)
+> Added: 2026-02-27
+
+**テスト対象パス**: `web/dropdown.ts`
+
+| Case ID | Input / Precondition                                                 | Perspective (Equivalence / Boundary) | Expected Result                                | Notes               |
+| ------- | -------------------------------------------------------------------- | ------------------------------------ | ---------------------------------------------- | ------------------- |
+| TC-006  | オプション名に HTML特殊文字を含む（例: `<script>alert(1)</script>`） | Equivalence - abnormal (XSS attempt) | 選択値表示にエスケープ済みテキストが設定される | escapeHtml 適用検証 |
+| TC-007  | オプション名が通常テキスト（例: `main`）                             | Equivalence - normal                 | テキストがそのまま表示される                   | 通常動作の維持      |
+| TC-008  | オプション名に `&`, `<`, `>`, `"`, `'` を含む                        | Boundary - all HTML entities         | すべての特殊文字が適切にエスケープされる       | 各エンティティ検証  |
+
+## S4: title 属性設定
+
+> Origin: Feature 005 (webview-ux-enhancements) (aidd-spec-tasks-test)
+> Added: 2026-02-27
+
+**テスト対象パス**: `web/dropdown.ts`
+
+| Case ID | Input / Precondition               | Perspective (Equivalence / Boundary) | Expected Result                                    | Notes                      |
+| ------- | ---------------------------------- | ------------------------------------ | -------------------------------------------------- | -------------------------- |
+| TC-009  | render() 実行後の選択値表示要素    | Equivalence - normal                 | title 属性にオプション名（生テキスト）が設定される | ブラウザがエスケープ       |
+| TC-010  | ドロップダウンオプション要素の描画 | Equivalence - normal                 | 各オプション div に title 属性が設定される         | ツールチップ用             |
+| TC-011  | 長いオプション名（100文字以上）    | Boundary - long text                 | title 属性にフルテキストが設定される               | 省略表示時のフルネーム表示 |
+
+## S5: マジックナンバー定数化
+
+> Origin: Feature 005 (webview-ux-enhancements) (aidd-spec-tasks-test)
+> Added: 2026-02-27
+
+**テスト対象パス**: `web/dropdown.ts`
+
+| Case ID | Input / Precondition     | Perspective (Equivalence / Boundary) | Expected Result | Notes                  |
+| ------- | ------------------------ | ------------------------------------ | --------------- | ---------------------- |
+| TC-012  | MIN_DROPDOWN_WIDTH 定数  | Equivalence - normal                 | 値が 130        | 最小幅                 |
+| TC-013  | SCROLLBAR_THRESHOLD 定数 | Equivalence - normal                 | 値が 272        | スクロールバー表示閾値 |
+| TC-014  | SCROLLBAR_WIDTH 定数     | Equivalence - normal                 | 値が 12         | スクロールバー幅       |
+| TC-015  | MAX_DROPDOWN_HEIGHT 定数 | Equivalence - normal                 | 値が 297        | 最大高さ               |

--- a/docs/testing/perspectives/web/messageHandler-test.md
+++ b/docs/testing/perspectives/web/messageHandler-test.md
@@ -27,3 +27,16 @@
 | ------- | ----------------------------------------------------------------------- | ------------------------------------ | --------------------------------------------------------------------- | ------------------------------------------------- |
 | TC-005  | refreshOrError経由コマンド (例: deleteBranch), status = null            | Equivalence - normal                 | gitGraph.refresh(false) が呼ばれる（hard=false でソフトリフレッシュ） | REQ-2.1: hard パラメータが false であることが重要 |
 | TC-006  | refreshOrError経由コマンド (例: deleteBranch), status = "error message" | Equivalence - error                  | showErrorDialog が呼ばれ、gitGraph.refresh は呼ばれない               | REQ-2.2: エラー時はリフレッシュしない             |
+
+## S3: handleMessage() selectRepo レスポンス処理
+
+> Origin: Feature 005 (webview-ux-enhancements) (aidd-spec-tasks-test)
+> Added: 2026-02-27
+
+**シグネチャ**: `handleMessage(msg: ResponseMessage, gitGraph: GitGraphViewAPI): void`
+**テスト対象パス**: `web/messageHandler.ts`
+
+| Case ID | Input / Precondition                       | Perspective (Equivalence / Boundary) | Expected Result                          | Notes                |
+| ------- | ------------------------------------------ | ------------------------------------ | ---------------------------------------- | -------------------- |
+| TC-007  | ResponseSelectRepo: repo = "/path/to/repo" | Equivalence - normal                 | gitGraph.selectRepo(msg.repo) が呼ばれる | 正常ルーティング     |
+| TC-008  | ResponseSelectRepo メッセージ処理          | Equivalence - normal                 | エラーなく処理が完了する                 | switch case 追加検証 |

--- a/media/dropdown.css
+++ b/media/dropdown.css
@@ -21,6 +21,12 @@
   cursor: pointer;
   user-select: none;
   white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 30vw;
+}
+body.singleRepo .dropdownCurrentValue {
+  max-width: 40vw;
 }
 .dropdownCurrentValue:hover {
   background-color: rgba(128, 128, 128, 0.2);
@@ -61,6 +67,8 @@
   cursor: pointer;
   padding: 4px 10px;
   user-select: none;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 .dropdownOptions.showInfo .dropdownOption {
   padding-right: 30px;

--- a/media/main.css
+++ b/media/main.css
@@ -9,6 +9,9 @@ body {
 body.unableToLoad {
   margin: 0 20px;
 }
+body.singleRepo #repoControl {
+  display: none;
+}
 body.unableToLoad h2,
 body.unableToLoad p {
   text-align: center;

--- a/package.json
+++ b/package.json
@@ -67,7 +67,11 @@
       {
         "category": "Git Keizu",
         "command": "git-keizu.view",
-        "title": "View Git Graph (git log)"
+        "title": "View Git Keizu (git log)",
+        "icon": {
+          "light": "resources/cmd-icon-light.svg",
+          "dark": "resources/cmd-icon-dark.svg"
+        }
       },
       {
         "category": "Git Keizu",
@@ -75,6 +79,19 @@
         "title": "Clear Avatar Cache"
       }
     ],
+    "menus": {
+      "scm/title": [
+        {
+          "command": "git-keizu.view",
+          "when": "scmProvider == git && config.git-keizu.sourceCodeProviderIntegrationLocation == 'Inline'",
+          "group": "navigation"
+        },
+        {
+          "command": "git-keizu.view",
+          "when": "scmProvider == git && config.git-keizu.sourceCodeProviderIntegrationLocation == 'More Actions'"
+        }
+      ]
+    },
     "configuration": {
       "type": "object",
       "title": "Git Keizu",
@@ -190,6 +207,44 @@
           ],
           "default": "colour",
           "description": "Specifies the colour theme of the icon displayed on the Git Graph tab."
+        },
+        "git-keizu.sourceCodeProviderIntegrationLocation": {
+          "type": "string",
+          "enum": [
+            "Inline",
+            "More Actions"
+          ],
+          "enumDescriptions": [
+            "Show the Git Graph button inline on the SCM title bar",
+            "Show the Git Graph button in the SCM title bar 'More Actions' menu"
+          ],
+          "default": "Inline",
+          "description": "Specifies where the Git Graph button is shown on the SCM title bar."
+        },
+        "git-keizu.keyboardShortcutFind": {
+          "type": "string",
+          "default": "CTRL/CMD + F",
+          "description": "Specifies the keyboard shortcut for opening the Find widget. Format: \"CTRL/CMD + <letter>\". Set to \"UNASSIGNED\" to disable."
+        },
+        "git-keizu.keyboardShortcutRefresh": {
+          "type": "string",
+          "default": "CTRL/CMD + R",
+          "description": "Specifies the keyboard shortcut for refreshing the graph. Format: \"CTRL/CMD + <letter>\". Set to \"UNASSIGNED\" to disable."
+        },
+        "git-keizu.keyboardShortcutScrollToHead": {
+          "type": "string",
+          "default": "CTRL/CMD + H",
+          "description": "Specifies the keyboard shortcut for scrolling to HEAD. Format: \"CTRL/CMD + <letter>\". Set to \"UNASSIGNED\" to disable."
+        },
+        "git-keizu.keyboardShortcutScrollToStash": {
+          "type": "string",
+          "default": "CTRL/CMD + S",
+          "description": "Specifies the keyboard shortcut for scrolling to Stash entries. Format: \"CTRL/CMD + <letter>\". Set to \"UNASSIGNED\" to disable."
+        },
+        "git-keizu.loadMoreCommitsAutomatically": {
+          "type": "boolean",
+          "default": true,
+          "description": "When enabled, automatically loads more commits when scrolling to the bottom of the graph."
         }
       }
     }

--- a/resources/cmd-icon-dark.svg
+++ b/resources/cmd-icon-dark.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
+  <!-- Left branch top -->
+  <line x1="4" y1="2.5" x2="4" y2="8" stroke="#b0b0b0" stroke-width="1.2" stroke-linecap="round"/>
+  <!-- Left branch bottom -->
+  <line x1="4" y1="8" x2="4" y2="13.5" stroke="#c0c0c0" stroke-width="1.2" stroke-linecap="round"/>
+  <!-- Center branch -->
+  <line x1="8" y1="2.5" x2="8" y2="13.5" stroke="#b8b8b8" stroke-width="1.2" stroke-linecap="round"/>
+  <!-- Right branch -->
+  <line x1="12" y1="2.5" x2="12" y2="13.5" stroke="#bcbcbc" stroke-width="1.2" stroke-linecap="round"/>
+  <!-- Connecting line -->
+  <line x1="4" y1="8" x2="12" y2="4.7" stroke="#c0c0c0" stroke-width="1.2" stroke-linecap="round"/>
+  <!-- Node: top right -->
+  <circle cx="12" cy="4.7" r="1.8" fill="#bcbcbc"/>
+  <!-- Node: middle left -->
+  <circle cx="4" cy="8" r="1.8" fill="#c0c0c0"/>
+  <!-- Node: bottom center -->
+  <circle cx="8" cy="11.3" r="1.8" fill="#b8b8b8"/>
+</svg>

--- a/resources/cmd-icon-light.svg
+++ b/resources/cmd-icon-light.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
+  <!-- Left branch top -->
+  <line x1="4" y1="2.5" x2="4" y2="8" stroke="#707070" stroke-width="1.2" stroke-linecap="round"/>
+  <!-- Left branch bottom -->
+  <line x1="4" y1="8" x2="4" y2="13.5" stroke="#606060" stroke-width="1.2" stroke-linecap="round"/>
+  <!-- Center branch -->
+  <line x1="8" y1="2.5" x2="8" y2="13.5" stroke="#686868" stroke-width="1.2" stroke-linecap="round"/>
+  <!-- Right branch -->
+  <line x1="12" y1="2.5" x2="12" y2="13.5" stroke="#646464" stroke-width="1.2" stroke-linecap="round"/>
+  <!-- Connecting line -->
+  <line x1="4" y1="8" x2="12" y2="4.7" stroke="#606060" stroke-width="1.2" stroke-linecap="round"/>
+  <!-- Node: top right -->
+  <circle cx="12" cy="4.7" r="1.8" fill="#646464"/>
+  <!-- Node: middle left -->
+  <circle cx="4" cy="8" r="1.8" fill="#606060"/>
+  <!-- Node: bottom center -->
+  <circle cx="8" cy="11.3" r="1.8" fill="#686868"/>
+</svg>

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,29 @@ import * as vscode from "vscode";
 
 import { DateFormat, DateType, GraphStyle, TabIconColourTheme } from "./types";
 
+const KEYBINDING_PATTERN = /^CTRL\/CMD \+ [A-Z]$/;
+const UNASSIGNED = "UNASSIGNED";
+
+/**
+ * Parse a keybinding setting value into a lowercase key letter or null.
+ * - Valid format (e.g. "CTRL/CMD + F") → lowercase letter ("f")
+ * - "UNASSIGNED" → null
+ * - Invalid value → fallback to parsing defaultValue
+ */
+export function parseKeybinding(value: string, defaultValue: string): string | null {
+  if (value === UNASSIGNED) {
+    return null;
+  }
+  if (KEYBINDING_PATTERN.test(value)) {
+    return value.charAt(value.length - 1).toLowerCase();
+  }
+  // Invalid value — fall back to default
+  if (KEYBINDING_PATTERN.test(defaultValue)) {
+    return defaultValue.charAt(defaultValue.length - 1).toLowerCase();
+  }
+  return null;
+}
+
 class Config {
   private workspaceConfiguration: vscode.WorkspaceConfiguration;
 
@@ -40,8 +63,32 @@ class Config {
     return this.workspaceConfiguration.get("initialLoadCommits", 300);
   }
 
+  public keyboardShortcutFind(): string | null {
+    const value = this.workspaceConfiguration.get("keyboardShortcutFind", "CTRL/CMD + F");
+    return parseKeybinding(value, "CTRL/CMD + F");
+  }
+
+  public keyboardShortcutRefresh(): string | null {
+    const value = this.workspaceConfiguration.get("keyboardShortcutRefresh", "CTRL/CMD + R");
+    return parseKeybinding(value, "CTRL/CMD + R");
+  }
+
+  public keyboardShortcutScrollToHead(): string | null {
+    const value = this.workspaceConfiguration.get("keyboardShortcutScrollToHead", "CTRL/CMD + H");
+    return parseKeybinding(value, "CTRL/CMD + H");
+  }
+
+  public keyboardShortcutScrollToStash(): string | null {
+    const value = this.workspaceConfiguration.get("keyboardShortcutScrollToStash", "CTRL/CMD + S");
+    return parseKeybinding(value, "CTRL/CMD + S");
+  }
+
   public loadMoreCommits() {
     return this.workspaceConfiguration.get("loadMoreCommits", 75);
+  }
+
+  public loadMoreCommitsAutomatically(): boolean {
+    return this.workspaceConfiguration.get("loadMoreCommitsAutomatically", true);
   }
 
   public maxDepthOfRepoSearch() {
@@ -58,6 +105,10 @@ class Config {
 
   public showUncommittedChanges() {
     return this.workspaceConfiguration.get("showUncommittedChanges", true);
+  }
+
+  public sourceCodeProviderIntegrationLocation(): "Inline" | "More Actions" {
+    return this.workspaceConfiguration.get("sourceCodeProviderIntegrationLocation", "Inline");
   }
 
   public tabIconColourTheme(): TabIconColourTheme {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,13 +18,25 @@ export function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     outputChannel,
-    vscode.commands.registerCommand("git-keizu.view", () => {
+    vscode.commands.registerCommand("git-keizu.view", (arg?: unknown) => {
+      // When invoked from SCM title bar, arg is a SourceControl object with rootUri property.
+      // When invoked from command palette or programmatically, arg may be a Uri or undefined.
+      let rootUri: vscode.Uri | undefined;
+      if (arg instanceof vscode.Uri) {
+        rootUri = arg;
+      } else if (arg !== null && arg !== undefined && typeof arg === "object" && "rootUri" in arg) {
+        const candidate = (arg as { rootUri?: unknown }).rootUri;
+        if (candidate instanceof vscode.Uri) {
+          rootUri = candidate;
+        }
+      }
       GitGraphView.createOrShow(
         context.extensionPath,
         dataSource,
         extensionState,
         avatarManager,
-        repoManager
+        repoManager,
+        rootUri
       );
     }),
     vscode.commands.registerCommand("git-keizu.clearAvatarCache", () => {

--- a/src/repoManager.ts
+++ b/src/repoManager.ts
@@ -127,7 +127,7 @@ export class RepoManager {
     }
     return repos;
   }
-  private addRepo(repo: string) {
+  public addRepo(repo: string) {
     this.repos[repo] = { columnWidths: null };
     this.extensionState.saveRepos(this.repos);
   }
@@ -179,6 +179,18 @@ export class RepoManager {
     }
     this.repos[repo] = state;
     this.extensionState.saveRepos(this.repos);
+  }
+
+  public async registerRepoFromUri(uri: vscode.Uri): Promise<void> {
+    const repoPath = getPathFromUri(uri);
+    if (repoPath in this.repos) {
+      return;
+    }
+    const isRepo = await this.dataSource.isGitRepository(repoPath);
+    if (isRepo) {
+      this.addRepo(repoPath);
+      this.sendRepos();
+    }
   }
 
   /* Repo Searching */

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,14 +69,23 @@ export interface GitUnsavedChanges {
   changes: number;
 }
 
+export interface KeybindingConfig {
+  find: string | null;
+  refresh: string | null;
+  scrollToHead: string | null;
+  scrollToStash: string | null;
+}
+
 export interface GitGraphViewState {
   dateFormat: DateFormat;
   fetchAvatars: boolean;
   graphColours: string[];
   graphStyle: GraphStyle;
   initialLoadCommits: number;
+  keybindings: KeybindingConfig;
   lastActiveRepo: string | null;
   loadMoreCommits: number;
+  loadMoreCommitsAutomatically: boolean;
   repos: GitRepoSet;
   showCurrentBranchByDefault: boolean;
 }
@@ -295,6 +304,11 @@ export interface ResponsePushTag {
 
 export interface ResponseRefresh {
   command: "refresh";
+}
+
+export interface ResponseSelectRepo {
+  command: "selectRepo";
+  repo: string;
 }
 
 export interface RequestRenameBranch {
@@ -526,6 +540,7 @@ export type ResponseMessage =
   | ResponsePushStash
   | ResponsePushTag
   | ResponseRefresh
+  | ResponseSelectRepo
   | ResponseRenameBranch
   | ResponseResetToCommit
   | ResponseResetUncommitted

--- a/tests/src/config.test.ts
+++ b/tests/src/config.test.ts
@@ -1,0 +1,258 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGet = vi.fn();
+
+vi.mock("vscode", () => ({
+  workspace: {
+    getConfiguration: vi.fn(() => ({
+      get: mockGet
+    }))
+  }
+}));
+
+import { getConfig, parseKeybinding } from "../../src/config";
+
+// S1: parseKeybinding() ショートカット設定値パース
+describe("parseKeybinding", () => {
+  // TC-001: valid format "CTRL/CMD + F" → "f"
+  it("returns lowercase letter for valid 'CTRL/CMD + F'", () => {
+    // Given: a valid keybinding format "CTRL/CMD + F"
+    // When: parseKeybinding is called
+    const result = parseKeybinding("CTRL/CMD + F", "CTRL/CMD + F");
+    // Then: returns the lowercase letter "f"
+    expect(result).toBe("f");
+  });
+
+  // TC-002: valid format "CTRL/CMD + Z" → "z"
+  it("returns lowercase letter for valid 'CTRL/CMD + Z'", () => {
+    // Given: a valid keybinding with a different letter
+    // When: parseKeybinding is called
+    const result = parseKeybinding("CTRL/CMD + Z", "CTRL/CMD + F");
+    // Then: extracts the last letter in lowercase
+    expect(result).toBe("z");
+  });
+
+  // TC-003: valid format "CTRL/CMD + A" → "a"
+  it("returns lowercase letter for valid 'CTRL/CMD + A'", () => {
+    // Given: a valid keybinding with the first alphabet letter
+    // When: parseKeybinding is called
+    const result = parseKeybinding("CTRL/CMD + A", "CTRL/CMD + F");
+    // Then: returns "a"
+    expect(result).toBe("a");
+  });
+
+  // TC-004: special value "UNASSIGNED" → null
+  it("returns null for UNASSIGNED", () => {
+    // Given: the special "UNASSIGNED" value to disable the shortcut
+    // When: parseKeybinding is called
+    const result = parseKeybinding("UNASSIGNED", "CTRL/CMD + F");
+    // Then: returns null
+    expect(result).toBeNull();
+  });
+
+  // TC-005: invalid format "Ctrl+F" → fallback to default "f"
+  it("falls back to default for invalid format 'Ctrl+F'", () => {
+    // Given: an invalid format missing slashes and spaces
+    // When: parseKeybinding is called
+    const result = parseKeybinding("Ctrl+F", "CTRL/CMD + F");
+    // Then: falls back to default → "f"
+    expect(result).toBe("f");
+  });
+
+  // TC-006: empty string → fallback to default "f"
+  it("falls back to default for empty string", () => {
+    // Given: an empty string input
+    // When: parseKeybinding is called
+    const result = parseKeybinding("", "CTRL/CMD + F");
+    // Then: falls back to default → "f"
+    expect(result).toBe("f");
+  });
+
+  // TC-007: lowercase "ctrl/cmd + f" → fallback to default "f"
+  it("falls back to default for lowercase 'ctrl/cmd + f'", () => {
+    // Given: lowercase variant (regex requires uppercase)
+    // When: parseKeybinding is called
+    const result = parseKeybinding("ctrl/cmd + f", "CTRL/CMD + F");
+    // Then: falls back to default → "f"
+    expect(result).toBe("f");
+  });
+
+  // TC-008: non-alpha "CTRL/CMD + 1" → fallback to default "f"
+  it("falls back to default for non-alpha 'CTRL/CMD + 1'", () => {
+    // Given: a digit instead of a letter
+    // When: parseKeybinding is called
+    const result = parseKeybinding("CTRL/CMD + 1", "CTRL/CMD + F");
+    // Then: falls back to default → "f"
+    expect(result).toBe("f");
+  });
+
+  // TC-009: extra whitespace → fallback to default "f"
+  it("falls back to default for value with extra whitespace", () => {
+    // Given: extra leading whitespace (strict regex requires exact match)
+    // When: parseKeybinding is called
+    const result = parseKeybinding(" CTRL/CMD + F", "CTRL/CMD + F");
+    // Then: regex fails, falls back to default → "f"
+    expect(result).toBe("f");
+  });
+
+  // TC-010: two-character key "CTRL/CMD + FF" → fallback to default "f"
+  it("falls back to default for two-character key 'CTRL/CMD + FF'", () => {
+    // Given: two characters after the plus sign (only single letter allowed)
+    // When: parseKeybinding is called
+    const result = parseKeybinding("CTRL/CMD + FF", "CTRL/CMD + F");
+    // Then: regex fails, falls back to default → "f"
+    expect(result).toBe("f");
+  });
+});
+
+// S2: sourceCodeProviderIntegrationLocation() SCMボタン位置設定
+describe("sourceCodeProviderIntegrationLocation", () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  // TC-011: default → "Inline"
+  it("returns 'Inline' as default when not configured", () => {
+    // Given: no setting configured (get returns the provided default)
+    mockGet.mockImplementation((_key: string, defaultValue: unknown) => defaultValue);
+    // When: reading the setting
+    const config = getConfig();
+    const result = config.sourceCodeProviderIntegrationLocation();
+    // Then: returns default "Inline"
+    expect(result).toBe("Inline");
+  });
+
+  // TC-012: configured "More Actions" → "More Actions"
+  it("returns 'More Actions' when configured", () => {
+    // Given: setting configured to "More Actions"
+    mockGet.mockImplementation((key: string, defaultValue: unknown) =>
+      key === "sourceCodeProviderIntegrationLocation" ? "More Actions" : defaultValue
+    );
+    // When: reading the setting
+    const config = getConfig();
+    const result = config.sourceCodeProviderIntegrationLocation();
+    // Then: returns "More Actions"
+    expect(result).toBe("More Actions");
+  });
+
+  // TC-013: explicitly configured "Inline" → "Inline"
+  it("returns 'Inline' when explicitly configured", () => {
+    // Given: setting explicitly set to "Inline"
+    mockGet.mockImplementation((key: string, defaultValue: unknown) =>
+      key === "sourceCodeProviderIntegrationLocation" ? "Inline" : defaultValue
+    );
+    // When: reading the setting
+    const config = getConfig();
+    const result = config.sourceCodeProviderIntegrationLocation();
+    // Then: returns "Inline"
+    expect(result).toBe("Inline");
+  });
+});
+
+// S3: keyboardShortcut*() キーボードショートカット設定
+describe("keyboardShortcut*", () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  // TC-014: keyboardShortcutFind default → "f"
+  it("keyboardShortcutFind returns 'f' by default", () => {
+    // Given: default configuration
+    mockGet.mockImplementation((_key: string, defaultValue: unknown) => defaultValue);
+    // When: reading keyboardShortcutFind
+    const config = getConfig();
+    const result = config.keyboardShortcutFind();
+    // Then: returns "f" (parsed from default "CTRL/CMD + F")
+    expect(result).toBe("f");
+  });
+
+  // TC-015: keyboardShortcutRefresh default → "r"
+  it("keyboardShortcutRefresh returns 'r' by default", () => {
+    // Given: default configuration
+    mockGet.mockImplementation((_key: string, defaultValue: unknown) => defaultValue);
+    // When: reading keyboardShortcutRefresh
+    const config = getConfig();
+    const result = config.keyboardShortcutRefresh();
+    // Then: returns "r" (parsed from default "CTRL/CMD + R")
+    expect(result).toBe("r");
+  });
+
+  // TC-016: keyboardShortcutScrollToHead default → "h"
+  it("keyboardShortcutScrollToHead returns 'h' by default", () => {
+    // Given: default configuration
+    mockGet.mockImplementation((_key: string, defaultValue: unknown) => defaultValue);
+    // When: reading keyboardShortcutScrollToHead
+    const config = getConfig();
+    const result = config.keyboardShortcutScrollToHead();
+    // Then: returns "h" (parsed from default "CTRL/CMD + H")
+    expect(result).toBe("h");
+  });
+
+  // TC-017: keyboardShortcutScrollToStash default → "s"
+  it("keyboardShortcutScrollToStash returns 's' by default", () => {
+    // Given: default configuration
+    mockGet.mockImplementation((_key: string, defaultValue: unknown) => defaultValue);
+    // When: reading keyboardShortcutScrollToStash
+    const config = getConfig();
+    const result = config.keyboardShortcutScrollToStash();
+    // Then: returns "s" (parsed from default "CTRL/CMD + S")
+    expect(result).toBe("s");
+  });
+
+  // TC-018: keyboardShortcutFind custom "CTRL/CMD + A" → "a"
+  it("keyboardShortcutFind returns custom key when configured", () => {
+    // Given: keyboardShortcutFind set to "CTRL/CMD + A"
+    mockGet.mockImplementation((key: string, defaultValue: unknown) =>
+      key === "keyboardShortcutFind" ? "CTRL/CMD + A" : defaultValue
+    );
+    // When: reading keyboardShortcutFind
+    const config = getConfig();
+    const result = config.keyboardShortcutFind();
+    // Then: returns "a"
+    expect(result).toBe("a");
+  });
+
+  // TC-019: keyboardShortcutFind "UNASSIGNED" → null
+  it("keyboardShortcutFind returns null when set to UNASSIGNED", () => {
+    // Given: keyboardShortcutFind set to "UNASSIGNED"
+    mockGet.mockImplementation((key: string, defaultValue: unknown) =>
+      key === "keyboardShortcutFind" ? "UNASSIGNED" : defaultValue
+    );
+    // When: reading keyboardShortcutFind
+    const config = getConfig();
+    const result = config.keyboardShortcutFind();
+    // Then: returns null (shortcut disabled)
+    expect(result).toBeNull();
+  });
+});
+
+// S4: loadMoreCommitsAutomatically() 自動読み込み設定
+describe("loadMoreCommitsAutomatically", () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  // TC-020: default → true
+  it("returns true by default", () => {
+    // Given: default configuration
+    mockGet.mockImplementation((_key: string, defaultValue: unknown) => defaultValue);
+    // When: reading loadMoreCommitsAutomatically
+    const config = getConfig();
+    const result = config.loadMoreCommitsAutomatically();
+    // Then: returns true (auto-load enabled by default)
+    expect(result).toBe(true);
+  });
+
+  // TC-021: configured false → false
+  it("returns false when explicitly disabled", () => {
+    // Given: setting configured to false
+    mockGet.mockImplementation((key: string, defaultValue: unknown) =>
+      key === "loadMoreCommitsAutomatically" ? false : defaultValue
+    );
+    // When: reading loadMoreCommitsAutomatically
+    const config = getConfig();
+    const result = config.loadMoreCommitsAutomatically();
+    // Then: returns false
+    expect(result).toBe(false);
+  });
+});

--- a/tests/web/dropdown.test.ts
+++ b/tests/web/dropdown.test.ts
@@ -1,0 +1,238 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  Dropdown,
+  MAX_DROPDOWN_HEIGHT,
+  MIN_DROPDOWN_WIDTH,
+  SCROLLBAR_THRESHOLD,
+  SCROLLBAR_WIDTH
+} from "../../web/dropdown";
+
+function createDropdownElement(id: string): HTMLElement {
+  const elem = document.createElement("div");
+  elem.id = id;
+  elem.className = "dropdown";
+  document.body.appendChild(elem);
+  return elem;
+}
+
+function openDropdown(dropdown: Dropdown, elem: HTMLElement): void {
+  const currentValueElem = elem.querySelector(".dropdownCurrentValue") as HTMLElement;
+  currentValueElem.click();
+}
+
+describe("isOpen", () => {
+  let dropdown: Dropdown;
+  let elem: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    elem = createDropdownElement("testDropdown");
+    dropdown = new Dropdown("testDropdown", false, "branches", () => {});
+    dropdown.setOptions(
+      [
+        { name: "main", value: "main" },
+        { name: "develop", value: "develop" }
+      ],
+      "main"
+    );
+  });
+
+  it("returns false when dropdown is in initial closed state (TC-001)", () => {
+    // Given: a newly created dropdown (initial state)
+    // When: isOpen() is called
+    const result = dropdown.isOpen();
+    // Then: it returns false
+    expect(result).toBe(false);
+  });
+
+  it("returns true after dropdown is opened (TC-002)", () => {
+    // Given: a closed dropdown
+    // When: the dropdown is opened by clicking the current value element
+    openDropdown(dropdown, elem);
+    // Then: isOpen() returns true
+    expect(dropdown.isOpen()).toBe(true);
+  });
+
+  it("returns false after open then close (TC-003)", () => {
+    // Given: an opened dropdown
+    openDropdown(dropdown, elem);
+    expect(dropdown.isOpen()).toBe(true);
+    // When: close() is called
+    dropdown.close();
+    // Then: isOpen() returns false
+    expect(dropdown.isOpen()).toBe(false);
+  });
+});
+
+describe("close", () => {
+  let dropdown: Dropdown;
+  let elem: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    elem = createDropdownElement("testDropdown");
+    dropdown = new Dropdown("testDropdown", false, "branches", () => {});
+    dropdown.setOptions(
+      [
+        { name: "main", value: "main" },
+        { name: "develop", value: "develop" }
+      ],
+      "main"
+    );
+  });
+
+  it("closes an open dropdown and sets isOpen to false (TC-004)", () => {
+    // Given: an opened dropdown
+    openDropdown(dropdown, elem);
+    expect(dropdown.isOpen()).toBe(true);
+    expect(elem.classList.contains("dropdownOpen")).toBe(true);
+    // When: close() is called
+    dropdown.close();
+    // Then: dropdown is closed, CSS class is removed, isOpen() returns false
+    expect(dropdown.isOpen()).toBe(false);
+    expect(elem.classList.contains("dropdownOpen")).toBe(false);
+  });
+
+  it("is idempotent when called on already closed dropdown (TC-005)", () => {
+    // Given: a closed dropdown
+    expect(dropdown.isOpen()).toBe(false);
+    // When: close() is called on an already closed dropdown
+    dropdown.close();
+    // Then: no error occurs, isOpen() remains false
+    expect(dropdown.isOpen()).toBe(false);
+    expect(elem.classList.contains("dropdownOpen")).toBe(false);
+  });
+});
+
+describe("escapeHtml XSS fix", () => {
+  let dropdown: Dropdown;
+  let elem: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    elem = createDropdownElement("testDropdown");
+    dropdown = new Dropdown("testDropdown", false, "branches", () => {});
+  });
+
+  it("escapes HTML special characters in selected value display (TC-006)", () => {
+    // Given: options containing XSS attempt in the name
+    const xssPayload = "<script>alert(1)</script>";
+    dropdown.setOptions([{ name: xssPayload, value: "xss" }], "xss");
+    // When: the dropdown renders
+    const currentValueElem = elem.querySelector(".dropdownCurrentValue") as HTMLElement;
+    // Then: innerHTML contains escaped text, not raw HTML tags
+    expect(currentValueElem.innerHTML).not.toContain("<script>");
+    expect(currentValueElem.innerHTML).toContain("&lt;script&gt;");
+  });
+
+  it("displays normal text unchanged (TC-007)", () => {
+    // Given: options with plain text name
+    dropdown.setOptions([{ name: "main", value: "main" }], "main");
+    // When: the dropdown renders
+    const currentValueElem = elem.querySelector(".dropdownCurrentValue") as HTMLElement;
+    // Then: text is displayed as-is
+    expect(currentValueElem.innerHTML).toBe("main");
+  });
+
+  it("escapes all HTML entities: &, <, >, quotes (TC-008)", () => {
+    // Given: option name containing all HTML special characters
+    const specialChars = "&<>\"'";
+    dropdown.setOptions([{ name: specialChars, value: "special" }], "special");
+    // When: the dropdown renders
+    const currentValueElem = elem.querySelector(".dropdownCurrentValue") as HTMLElement;
+    // Then: dangerous characters (&, <, >) are escaped in innerHTML
+    expect(currentValueElem.innerHTML).toContain("&amp;");
+    expect(currentValueElem.innerHTML).toContain("&lt;");
+    expect(currentValueElem.innerHTML).toContain("&gt;");
+    // Then: textContent round-trips correctly (DOM parsed the escaped values back)
+    expect(currentValueElem.textContent).toBe(specialChars);
+    // Then: innerHTML differs from the raw input (escaping was applied)
+    expect(currentValueElem.innerHTML).not.toBe(specialChars);
+  });
+});
+
+describe("title attribute", () => {
+  let dropdown: Dropdown;
+  let elem: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    elem = createDropdownElement("testDropdown");
+    dropdown = new Dropdown("testDropdown", false, "branches", () => {});
+  });
+
+  it("sets title attribute on selected value element with raw text (TC-009)", () => {
+    // Given: a dropdown with options
+    dropdown.setOptions(
+      [
+        { name: "main", value: "main" },
+        { name: "develop", value: "develop" }
+      ],
+      "main"
+    );
+    // When: the dropdown renders
+    const currentValueElem = elem.querySelector(".dropdownCurrentValue") as HTMLElement;
+    // Then: title attribute contains raw (unescaped) option name
+    expect(currentValueElem.title).toBe("main");
+  });
+
+  it("sets title attribute on each dropdown option div (TC-010)", () => {
+    // Given: a dropdown with multiple options
+    const options = [
+      { name: "main", value: "main" },
+      { name: "feature/test", value: "feature/test" }
+    ];
+    dropdown.setOptions(options, "main");
+    // When: the options are rendered
+    const optionElems = elem.querySelectorAll(".dropdownOption");
+    // Then: each option div has a title attribute with its name
+    expect(optionElems.length).toBe(2);
+    expect((optionElems[0] as HTMLElement).title).toContain("main");
+    expect((optionElems[1] as HTMLElement).title).toContain("feature");
+  });
+
+  it("sets full text in title for long option names over 100 chars (TC-011)", () => {
+    // Given: an option with a very long name (100+ characters)
+    const longName = "a".repeat(150);
+    dropdown.setOptions([{ name: longName, value: "long" }], "long");
+    // When: the dropdown renders
+    const currentValueElem = elem.querySelector(".dropdownCurrentValue") as HTMLElement;
+    // Then: title contains the full untruncated text
+    expect(currentValueElem.title).toBe(longName);
+    expect(currentValueElem.title.length).toBe(150);
+  });
+});
+
+describe("magic number constants", () => {
+  it("MIN_DROPDOWN_WIDTH equals 130 (TC-012)", () => {
+    // Given: the MIN_DROPDOWN_WIDTH constant is exported
+    // When: its value is checked
+    // Then: it equals 130
+    expect(MIN_DROPDOWN_WIDTH).toBe(130);
+  });
+
+  it("SCROLLBAR_THRESHOLD equals 272 (TC-013)", () => {
+    // Given: the SCROLLBAR_THRESHOLD constant is exported
+    // When: its value is checked
+    // Then: it equals 272
+    expect(SCROLLBAR_THRESHOLD).toBe(272);
+  });
+
+  it("SCROLLBAR_WIDTH equals 12 (TC-014)", () => {
+    // Given: the SCROLLBAR_WIDTH constant is exported
+    // When: its value is checked
+    // Then: it equals 12
+    expect(SCROLLBAR_WIDTH).toBe(12);
+  });
+
+  it("MAX_DROPDOWN_HEIGHT equals 297 (TC-015)", () => {
+    // Given: the MAX_DROPDOWN_HEIGHT constant is exported
+    // When: its value is checked
+    // Then: it equals 297
+    expect(MAX_DROPDOWN_HEIGHT).toBe(297);
+  });
+});

--- a/tests/web/messageHandler.test.ts
+++ b/tests/web/messageHandler.test.ts
@@ -22,7 +22,8 @@ function createMockGitGraphView(): GitGraphViewAPI {
     loadBranches: vi.fn(),
     loadCommits: vi.fn(),
     loadRepos: vi.fn(),
-    refresh: vi.fn()
+    refresh: vi.fn(),
+    selectRepo: vi.fn()
   };
 }
 
@@ -131,5 +132,35 @@ describe("handleMessage push response", () => {
     expect(showErrorDialog).toHaveBeenCalledTimes(1);
     expect(showErrorDialog).toHaveBeenCalledWith("Unable to Push", errorMsg, null);
     expect(gitGraph.refresh).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleMessage selectRepo response (S3)", () => {
+  let gitGraph: GitGraphViewAPI;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    gitGraph = createMockGitGraphView();
+  });
+
+  it("routes selectRepo message to gitGraph.selectRepo with repo path (TC-007)", () => {
+    // Given: A selectRepo response with a repo path
+    const msg: ResponseMessage = { command: "selectRepo", repo: "/path/to/repo" };
+
+    // When: handleMessage is called with the selectRepo response
+    handleMessage(msg, gitGraph);
+
+    // Then: gitGraph.selectRepo is called with the repo path
+    expect(gitGraph.selectRepo).toHaveBeenCalledTimes(1);
+    expect(gitGraph.selectRepo).toHaveBeenCalledWith("/path/to/repo");
+  });
+
+  it("completes without error on selectRepo message (TC-008)", () => {
+    // Given: A selectRepo response message
+    const msg: ResponseMessage = { command: "selectRepo", repo: "/some/other/repo" };
+
+    // When/Then: handleMessage processes without throwing
+    expect(() => handleMessage(msg, gitGraph)).not.toThrow();
+    expect(gitGraph.selectRepo).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/dropdown.ts
+++ b/web/dropdown.ts
@@ -1,5 +1,10 @@
 import { escapeHtml, svgIcons } from "./utils";
 
+export const MIN_DROPDOWN_WIDTH = 130;
+export const SCROLLBAR_THRESHOLD = 272;
+export const SCROLLBAR_WIDTH = 12;
+export const MAX_DROPDOWN_HEIGHT = 297;
+
 interface DropdownOption {
   name: string;
   value: string;
@@ -86,13 +91,6 @@ export class Dropdown {
       true
     );
     document.addEventListener("contextmenu", () => this.close(), true);
-    document.addEventListener(
-      "keyup",
-      (e) => {
-        if (e.key === "Escape") this.close();
-      },
-      true
-    );
     this.filterInput.addEventListener("keyup", () => this.filter());
   }
 
@@ -115,27 +113,28 @@ export class Dropdown {
 
   private render() {
     this.elem.classList.add("loaded");
-    this.currentValueElem.innerHTML = this.options[this.selectedOption].name;
+    const currentOption = this.options[this.selectedOption];
+    this.currentValueElem.innerHTML = escapeHtml(currentOption.name);
+    this.currentValueElem.title = currentOption.name;
     let html = "";
     for (let i = 0; i < this.options.length; i++) {
       const selectedClass = this.selectedOption === i ? " selected" : "";
       const infoHtml = this.showInfo
         ? `<div class="dropdownOptionInfo" title="${escapeHtml(this.options[i].value)}">${svgIcons.info}</div>`
         : "";
-      html += `<div class="dropdownOption${selectedClass}" data-id="${i}">${escapeHtml(this.options[i].name)}${infoHtml}</div>`;
+      html += `<div class="dropdownOption${selectedClass}" data-id="${i}" title="${escapeHtml(this.options[i].name)}">${escapeHtml(this.options[i].name)}${infoHtml}</div>`;
     }
     this.optionsElem.className = `dropdownOptions${this.showInfo ? " showInfo" : ""}`;
     this.optionsElem.innerHTML = html;
     this.filterInput.style.display = "none";
     this.noResultsElem.style.display = "none";
     this.menuElem.style.cssText = "opacity:0; display:block;";
-    // Width must be at least 130px for the filter elements. Max height for the dropdown is [filter (31px) + 9.5 * dropdown item (28px) = 297px]
-    // Don't need to add 12px if showing info icons and scrollbar isn't needed. The scrollbar isn't needed if: menuElem height + filter input (25px) < 297px
     this.currentValueElem.style.width = `${Math.max(
-      this.menuElem.offsetWidth + (this.showInfo && this.menuElem.offsetHeight < 272 ? 0 : 12),
-      130
+      this.menuElem.offsetWidth +
+        (this.showInfo && this.menuElem.offsetHeight < SCROLLBAR_THRESHOLD ? 0 : SCROLLBAR_WIDTH),
+      MIN_DROPDOWN_WIDTH
     )}px`;
-    this.menuElem.style.cssText = "right:0; overflow-y:auto; max-height:297px;";
+    this.menuElem.style.cssText = `right:0; overflow-y:auto; max-height:${MAX_DROPDOWN_HEIGHT}px;`;
     if (this.dropdownVisible) this.filter();
   }
 
@@ -152,7 +151,11 @@ export class Dropdown {
     this.noResultsElem.style.display = matches ? "none" : "block";
   }
 
-  private close() {
+  public isOpen(): boolean {
+    return this.dropdownVisible;
+  }
+
+  public close() {
     this.elem.classList.remove("dropdownOpen");
     this.dropdownVisible = false;
   }

--- a/web/global.d.ts
+++ b/web/global.d.ts
@@ -15,7 +15,9 @@ declare global {
     graphStyle: "rounded" | "angular";
     grid: { x: number; y: number; offsetX: number; offsetY: number; expandY: number };
     initialLoadCommits: number;
+    keybindings: GG.KeybindingConfig;
     loadMoreCommits: number;
+    loadMoreCommitsAutomatically: boolean;
     showCurrentBranchByDefault: boolean;
   }
 

--- a/web/messageHandler.ts
+++ b/web/messageHandler.ts
@@ -23,6 +23,7 @@ export interface GitGraphViewAPI {
   ): void;
   loadRepos(repos: GitRepoSet, lastActiveRepo: string | null): void;
   refresh(hard: boolean): void;
+  selectRepo(repo: string): void;
 }
 
 export function handleMessage(msg: ResponseMessage, gitGraph: GitGraphViewAPI): void {
@@ -132,6 +133,9 @@ export function handleMessage(msg: ResponseMessage, gitGraph: GitGraphViewAPI): 
       break;
     case "revertCommit":
       refreshOrError(gitGraph, msg.status, "Unable to Revert Commit");
+      break;
+    case "selectRepo":
+      gitGraph.selectRepo(msg.repo);
       break;
     case "viewDiff":
       if (msg.success === false) showErrorDialog("Unable to view diff of file", null, null);


### PR DESCRIPTION
# Issue

- N/A

# 背景・目的

本家 Git Graph が提供していた4つの主要 UX 機能（SCM ビューボタン統合・キーボードショートカット・コミット自動追加読み込み・ドロップダウン幅制御）を Git Keizu に実装し、操作性を大幅に向上させる。

# 変更内容

## SCM ビュー統合（REQ-2.1 / REQ-2.2）

- `package.json`: `scm/title` メニューへのボタン追加（Inline / More Actions 切り替え対応）、コマンドにアイコンを設定
- `resources/cmd-icon-light.svg`, `resources/cmd-icon-dark.svg`: ライト/ダーク両テーマ用 16×16 SVG アイコンを新規作成
- `src/extension.ts`: `git-keizu.view` コマンドハンドラで SCM タイトルバーからの `rootUri` 引数（SourceControl.rootUri）を受け取る対応を追加
- `src/gitGraphView.ts`: `createOrShow()` に `rootUri` 引数を追加し、指定リポジトリを自動選択・未登録時は登録してから表示するロジックを実装
- `src/repoManager.ts`: `registerRepoFromUri()` メソッドを追加（URI から Git リポジトリを検証・登録）
- `src/config.ts`: `sourceCodeProviderIntegrationLocation()` を追加

## キーボードショートカット（REQ-9.1 / REQ-9.2 / REQ-9.3）

- `src/config.ts`: `parseKeybinding()` ユーティリティ関数を追加（正規表現バリデーション・UNASSIGNED→null・無効値→デフォルト フォールバック）。`keyboardShortcutFind/Refresh/ScrollToHead/ScrollToStash()` を追加
- `package.json`: 4つのキーボードショートカット設定項目を追加（デフォルト: Ctrl/Cmd + F/R/H/S）
- `web/main.ts`: `handleKeyboardShortcut()` で 4 アクションのディスパッチを実装。`scrollToStash()` で循環ナビゲーション・タイムアウトリセット（5秒）・フラッシュ効果を実装。`handleEscape()` でコンテキストメニュー→ダイアログ→ドロップダウン→FindWidget→コミット詳細の段階的 UI 解除チェーンを実装
- `web/global.d.ts`: Config インターフェースに `keybindings` と `loadMoreCommitsAutomatically` を追加
- `src/gitGraphView.ts`: `getHtmlForWebview()` の viewState にキーバインド設定・自動読み込み設定を追加

## コミット自動追加読み込み（REQ-2.3）

- `package.json`: `loadMoreCommitsAutomatically` boolean 設定を追加（デフォルト: true）
- `src/config.ts`: `loadMoreCommitsAutomatically()` を追加
- `web/main.ts`: スクロール監視を拡張し、スクロール末尾から 25px 以内で自動読み込みを発火（3ガード条件: 設定有効 + 未読み込みあり + 読み込み中でない）

## ドロップダウン幅制御とテキスト省略（REQ-2.4）

- `media/dropdown.css`: `text-overflow: ellipsis`・`overflow: hidden`・`max-width: 30vw` を追加。単一リポジトリ時は `body.singleRepo` セレクタで `max-width: 40vw` に拡大
- `media/main.css`: `body.singleRepo #repoControl { display: none }` でリポジトリ選択を非表示に
- `web/dropdown.ts`: `close()` メソッドをパブリック化（Escape チェーン対応）、各オプションに `title` 属性追加（ツールチップ）、`escapeHtml` 適用による XSS 修正、マジックナンバーを名前付き定数に抽出

## テスト

- `tests/src/config.test.ts`: 新規作成（parseKeybinding・各ショートカット設定・自動読み込み設定）
- `tests/src/gitGraphView.test.ts`: rootUri ハンドリング・viewState 設定受け渡しのテストを追加
- `tests/web/dropdown.test.ts`: 新規作成（isOpen・close・XSS・title 属性・定数値）
- `tests/web/main.test.ts`: handleKeyboardShortcut・scrollToStash・handleEscape・自動読み込み・selectRepo のテストを大幅追加
- `tests/web/messageHandler.test.ts`: ResponseSelectRepo ルーティングのテストを追加

## テスト観点表（docs）

- `docs/testing/perspectives/` 以下に Feature 005 対応の観点表を新規追加・更新（INDEX.md 含む）

# 技術的な詳細

- `parseKeybinding()` は `src/config.ts` からエクスポートし、単体テスト可能な設計にした（KEYBINDING_PATTERN 定数と UNASSIGNED 定数を使用）
- SCM ボタンの `rootUri` 受け取りは VS Code API の型定義上 `unknown` であるため、`instanceof vscode.Uri` と `"rootUri" in arg` の両パターンでガードしている
- stash ナビゲーションのタイムアウトは `STASH_NAVIGATION_TIMEOUT_MS` 定数（5000ms）で管理

# 影響範囲・互換性

- 破壊的変更（Breaking）: ➖
- DBマイグレーション: ➖
- 環境変数の追加/変更: ➖
- 外部API/スキーマ変更: ➖
- 認証/認可ロジック: ➖
- パフォーマンス影響: ➖（スクロールイベントは既存のものを拡張）

# 動作確認手順

1. 拡張機能をビルドして VS Code にインストール（`pnpm run compile`）
2. SCM パネルのタイトルバーに Git Keizu アイコンボタンが表示されることを確認
3. ボタンをクリックし、対応するリポジトリのグラフビューが開くことを確認
4. グラフビューで Ctrl+F / Ctrl+R / Ctrl+H / Ctrl+S の各ショートカットが動作することを確認
5. コミット履歴が多いリポジトリで、スクロール末尾に達したとき自動的に追加読み込みされることを確認
6. 長いブランチ名が省略表示（`...`）され、マウスオーバーでフルネームのツールチップが表示されることを確認

# テスト

- 自動テスト: `pnpm run test:ci`（27ファイル変更、新規テストファイル4件追加。合計テストケース数は大幅増加）
- 手動確認: 上記「動作確認手順」参照

# リスク・懸念点・ロールバック

- リスク/既知の制約: SCM タイトルバー統合は VS Code の when 条件式（`scmProvider == git`）に依存するため、Git 以外の SCM プロバイダでは非表示となる設計
- ロールバック手順: このブランチを main にマージしない、または revert コミットを作成

# レビューポイント

- `src/extension.ts` の `rootUri` 取得ロジック（`instanceof vscode.Uri` と `"rootUri" in arg` の二段階ガード）
- `web/main.ts` の `handleEscape()` の優先チェーン順序が仕様書通りか
- `web/dropdown.ts` の `escapeHtml` 適用箇所が XSS 防止として十分か

# マージ前チェックリスト

## セキュリティ
- ✅ シークレットのハードコード無し/環境変数で管理
- ✅ 入力バリデーション/サニタイズの適切性（parseKeybinding の正規表現検証、dropdown の escapeHtml 適用）
- ➖ 権限/CSRF/レート制限に影響なし

## ドキュメント
- ➖ README/DB設計/OpenAPI etc. 更新（README には影響なし）
- ➖ .env.example 更新（環境変数追加なし）
- ➖ スクショ/動画添付（UI変更あるが割愛）