### PR TITLE
chore: adapt release skills to PR-protected main

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: release
-description: "VSマーケットプレイスとOpenVSXへのリリース（バージョンバンプ → タグ作成 → push → GitHub Actions 自動公開）"
-allowed-tools: Read, Edit, Bash(cd:*), Bash(git status:*), Bash(git diff:*), Bash(git log:*), Bash(git add:*), Bash(git commit:*), Bash(git tag:*), Bash(npx:*)
-argument-hint: <version> # 例: v0.2.2 または 0.2.2
+description: "リリース実行: リリース準備 PR マージ後の main を検証し、タグを作成してタグ push で GitHub Actions の公開を起動する"
+allowed-tools: Read, Bash(cd:*), Bash(git status:*), Bash(git log:*), Bash(git fetch:*), Bash(git switch:*), Bash(git pull:*), Bash(git tag:*), Bash(git ls-remote:*), Bash(npx:*)
+argument-hint: <version> # 例: v0.9.0 または 0.9.0
 ---
 
-# Release Workflow
+# Release Workflow（タグ作成 → 公開）
 
-VS Code 拡張機能 git-keizu を VSマーケットプレイスと OpenVSX に公開します。
+VS Code 拡張機能 git-keizu を VS Marketplace と OpenVSX に公開します。
 `v*` タグを GitHub に push すると、`.github/workflows/publish.yml` が自動で以下を実行します:
 
 - VSIX ビルド
@@ -15,114 +15,100 @@ VS Code 拡張機能 git-keizu を VSマーケットプレイスと OpenVSX に�
 - OpenVSX への公開（`OPEN_VSX_TOKEN`）
 - GitHub Release 作成（VSIX 添付）
 
+> main は ruleset（pull_request 必須）で保護されているため、リリース準備 commit
+> （CHANGELOG / README / バージョンバンプ）は本スキルでは作らず、事前に
+> `/update-release-docs` の PR で main へマージしておくこと。
+> 本スキルは main の状態検証とタグ作成だけを行い、push するのは**タグのみ**
+> （タグ push はブランチ ruleset の対象外）。
+
+リリースフロー全体:
+
+```
+1. /update-release-docs <要件ドキュメント> <バージョン>   ← docs + bump の PR 作成
+2. PR をマージ（ユーザー）
+3. /release <バージョン>                                  ← 本スキル
+```
+
 ## 前提条件
 
 - リポジトリルート: `~/work/ai/git-keizu`
 - 最初の Bash tool call で必ず `cd ~/work/ai/git-keizu` を実行すること
+- `/update-release-docs` のリリース準備 PR（CHANGELOG / README / package.json バンプ）がマージ済みであること
 - GitHub Secrets に `VS_MARKETPLACE_TOKEN` と `OPEN_VSX_TOKEN` が設定済みであること
 
 ## 引数（$ARGUMENTS）
 
 リリースするバージョンを指定します。`v` プレフィックスはあってもなくても可。
 
-- `/release v0.2.2` → バージョン `0.2.2` でリリース
-- `/release 0.2.2` → 同上
+- `/release v0.9.0` → バージョン `0.9.0` でリリース
+- `/release 0.9.0` → 同上
+
+引数が指定されていない場合はエラーを出力して中止する。
 
 ## 実行手順
 
 ### Step 1: バージョン引数の正規化
 
-`$ARGUMENTS` からバージョン番号を取得し、以下の形式に正規化する:
+`$ARGUMENTS` から取得したバージョンを、タグ形式 `v0.9.0` とパッケージ形式 `0.9.0` に正規化する。
 
-- **タグ形式**: `v0.2.2`（`v` プレフィックスあり）
-- **パッケージ形式**: `0.2.2`（`v` プレフィックスなし）
-
-引数が指定されていない場合はエラーを出力して中止する:
-
-```
-エラー: バージョン番号を指定してください。
-例: /release v0.2.2
-```
-
-### Step 2: リポジトリルートへ移動
+### Step 2: main を最新化
 
 ```bash
 cd ~/work/ai/git-keizu
+git fetch origin
+git switch main
+git pull --ff-only origin main
+git status
 ```
 
-### Step 3: ワーキングツリーの状態確認
+- working tree に未コミット変更がある場合は中断してユーザーに報告する。
+- `--ff-only` の pull が失敗した場合（ローカル main がリモートと乖離）は中断してユーザーに報告する。
 
-`git status` を実行し、コミットされていない変更を確認する。
+### Step 3: リリース準備が main に入っていることの検証（必須）
 
-- **変更がある場合**: 変更内容を表示し、以下を確認してユーザーに報告する
-  - バージョンバンプ以外の変更がある場合は、先にそれらをコミットするよう促す
-  - リリース作業を続行するか確認を求める
-- **クリーンな場合**: そのまま続行
+以下をすべて確認する。1つでも満たさない場合は中断し、`/update-release-docs` の実行または PR のマージを促す:
 
-### Step 4: 現在のバージョン確認
+1. `package.json` の `"version"` が **パッケージ形式バージョンと一致**する（Read ツールで確認）
+2. `CHANGELOG.md` に `## [{パッケージ形式バージョン}]` エントリが存在する
+3. `git log -5 --oneline` にリリース準備 commit（docs / bump）が含まれることを目視確認する
 
-`package.json` を Read ツールで読み込み、現在の `"version"` フィールドを確認する。
+### Step 4: CI チェック（推奨）
 
-- **現在のバージョン == 指定バージョン**: バンプ不要、Step 6 へスキップ
-- **現在のバージョン != 指定バージョン**: Step 5 でバンプを実行
-
-### Step 5: package.json バージョンバンプ
-
-Edit ツールで `package.json` の `"version"` フィールドを更新する。
-
-更新後、以下の手順でコミットする:
+タグ push 前の最終品質チェック。いずれかが失敗した場合は中止してユーザーに報告する:
 
 ```bash
-# ステージング
-git add package.json
-
-# コミット（バージョン番号は実際の値に置き換え）
-git commit -m "chore: bump version to <パッケージ形式バージョン>"
+npx --yes pnpm@10.34.5 run format
+npx --yes pnpm@10.34.5 run lint
+npx --yes pnpm@10.34.5 run typecheck
+npx --yes pnpm@10.34.5 run test:ci
 ```
 
-### Step 6: CI チェック（任意）
-
-⚠️ タグ push 前に品質チェックを行うことを推奨する。
-
-以下を順番に実行する（いずれかが失敗した場合は中止してユーザーに報告する）:
-
-```bash
-npx --yes pnpm@10.29.3 run format
-npx --yes pnpm@10.29.3 run lint
-npx --yes pnpm@10.29.3 run typecheck
-npx --yes pnpm@10.29.3 run test:ci
-```
-
-失敗した場合はエラー内容を表示して中止する。
-
-### Step 7: タグが既存でないか確認
+### Step 5: タグが既存でないか確認
 
 ```bash
 git tag -l <タグ形式バージョン>
+git ls-remote --tags origin <タグ形式バージョン>
 ```
 
-- **タグが既に存在する場合**: エラーを出力して中止する
-  ```
-  エラー: タグ v0.2.2 は既に存在します。
-  別のバージョンを指定するか、既存タグを削除してください。
-  ```
-- **タグが存在しない場合**: そのまま続行
+- ローカル・リモートいずれかにタグが既に存在する場合はエラーを出力して中止する。
 
-### Step 8: タグ作成
+### Step 6: タグ作成
 
 ```bash
 git tag <タグ形式バージョン>
 ```
 
-### Step 9: Push（手動実行）
+### Step 7: タグ push（手動実行）
 
-push はアヤ（AI）では実行しない。以下のコマンドをリアに伝え、ターミナルで実行してもらう:
+push は AI では実行しない。以下のコマンドをユーザーに伝え、ターミナルで実行してもらう:
 
 ```
 以下のコマンドをターミナルで実行してください:
 
-git push origin main && git push origin <タグ形式バージョン>
+git push origin <タグ形式バージョン>
 ```
+
+main の push は不要（リリース準備 PR のマージで反映済み）。
 
 ## 完了報告
 
@@ -132,11 +118,11 @@ git push origin main && git push origin <タグ形式バージョン>
 ## リリース準備完了
 
 - バージョン: <タグ形式バージョン>
-- コミット: chore: bump version to <パッケージ形式バージョン>
-- タグ: <タグ形式バージョン>（ローカル作成済み）
+- タグ: <タグ形式バージョン>（ローカル作成済み、対象 commit: <hash>）
+- 検証: package.json / CHANGELOG / CI チェックの結果
 
 ### 以下のコマンドをターミナルで実行してください
-git push origin main && git push origin <タグ形式バージョン>
+git push origin <タグ形式バージョン>
 
 push 後、GitHub Actions が自動で publish.yml を実行し、VS Marketplace と OpenVSX への公開と GitHub Release 作成が行われます。
 https://github.com/numlia/git-keizu/actions/workflows/publish.yml
@@ -144,7 +130,7 @@ https://github.com/numlia/git-keizu/actions/workflows/publish.yml
 
 ## 注意事項
 
-- **コマンドは1つずつ実行**: `&&` や `;` で繋げない（allowed-tools の制約）
-- **cd は最初の1回のみ**: 以降のコマンドはシンプルな形式で実行
-- **タグの push は慎重に**: push 後のタグ削除は `git push origin --delete <tag>` が必要
+- **main へは何もコミットしない**: バージョンバンプを含む一切の commit は本スキルの対象外
+- **push するのはタグのみ**: `git push origin main` は実行しない（ruleset で拒否される）
+- **タグの push は慎重に**: push 後のタグ削除は `git push origin --delete <tag>` が必要で、公開 workflow が起動してしまうため原則やり直し不可と考える
 - **GitHub Secrets 未設定の場合**: publish workflow は失敗するため、事前に GitHub リポジトリの Settings > Secrets で確認すること

--- a/.claude/skills/update-release-docs/SKILL.md
+++ b/.claude/skills/update-release-docs/SKILL.md
@@ -1,20 +1,34 @@
 ---
 name: update-release-docs
-description: "main との差分と要件ドキュメントを参考に、次バージョン用の README と CHANGELOG を更新する"
-allowed-tools: Read, Edit, Bash(cd:*), Bash(git log:*), Bash(git diff:*), Bash(git status:*), Bash(git add:*), Bash(git commit:*)
-argument-hint: <要件ドキュメントのパス> [バージョン] # 例: notes/features/007-xxx/要件整理.md 0.2.7
+description: "リリース準備: 前回リリースタグとの差分と要件ドキュメントから CHANGELOG / README を更新し、バージョンバンプとあわせてリリース準備 PR を作成する"
+allowed-tools: Read, Edit, Bash(cd:*), Bash(git log:*), Bash(git diff:*), Bash(git status:*), Bash(git tag:*), Bash(git switch:*), Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(gh pr:*)
+argument-hint: <要件ドキュメントのパス> [バージョン] # 例: notes/features/052/memo.md 0.9.0
 ---
 
-# Release Docs Update Workflow
+# Release Prep Workflow（docs + version bump → PR）
 
-main ブランチとの差分と指定された要件ドキュメントを参照し、
-次バージョン用の `CHANGELOG.md` と `README.md` を更新します。
+前回リリースタグ以降の main の変更と指定された要件ドキュメントを参照し、
+次バージョン用の `CHANGELOG.md` / `README.md` の更新と `package.json` のバージョンバンプを
+**リリース準備ブランチ + Draft PR** として作成します。
+
+> main ブランチは ruleset（pull_request 必須・bypass なし）で保護されているため、
+> リリース準備 commit を main へ直接 push することはできません。
+> 本スキルは PR 作成まで、タグ作成と公開トリガーは `/release` が担当します。
+
+リリースフロー全体:
+
+```
+1. /update-release-docs <要件ドキュメント> <バージョン>   ← 本スキル（docs + bump の PR 作成）
+2. PR をマージ（ユーザー）
+3. /release <バージョン>                                  ← 検証 → タグ作成 → タグ push
+```
 
 ## 前提条件
 
 - リポジトリルート: `~/work/ai/git-keizu`
 - 最初の Bash tool call で必ず `cd ~/work/ai/git-keizu` を実行すること
-- 現在のブランチが機能ブランチ（main ではない）であること
+- リリース対象の機能 PR がすべて main へマージ済みであること
+- ローカル main が `origin/main` と一致していること（`git status` で確認。乖離している場合は中断してユーザーに報告する）
 
 ## 引数（$ARGUMENTS）
 
@@ -23,21 +37,13 @@ main ブランチとの差分と指定された要件ドキュメントを参照
 | 位置    | 必須   | 説明                                                                   |
 | ------- | ------ | ---------------------------------------------------------------------- |
 | 第1引数 | 必須   | 要件ドキュメントのパス（リポジトリルートからの相対パスまたは絶対パス） |
-| 第2引数 | 省略可 | バージョン番号（例: `0.2.7` または `v0.2.7`、v-prefix は任意）         |
-
-```
-# バージョンを明示する場合
-/update-release-docs notes/features/007-foo/要件整理.md 0.2.7
-
-# バージョンを省略する場合（package.json から自動取得）
-/update-release-docs notes/features/007-foo/要件整理.md
-```
+| 第2引数 | 省略可 | バージョン番号（例: `0.9.0` または `v0.9.0`、v-prefix は任意）         |
 
 引数が指定されていない場合は、要件ドキュメントのパスをユーザーに確認してから進めること。
 
 ## ⚠️ CRITICAL: ドキュメント更新前に必ず実行すること
 
-コミットメッセージを生成する前に、以下を必ず実行すること。
+コミットメッセージ・PR 本文を生成する前に、以下を必ず実行すること。
 
 ### 言語設定の確認（MANDATORY）
 
@@ -52,70 +58,68 @@ main ブランチとの差分と指定された要件ドキュメントを参照
 
 ## 実行手順
 
-### Step 1: リポジトリルートへ移動
+### Step 1: リポジトリルートへ移動と前提確認
 
 ```bash
 cd ~/work/ai/git-keizu
+git status
 ```
+
+- 現在のブランチが main でない、または working tree に未コミット変更がある場合は中断してユーザーに報告する。
 
 ### Step 2: 情報収集（並列実行可）
 
-以下を並列で Read/Bash 実行し、内容を把握する:
-
-1. **要件ドキュメントを読む**: `$ARGUMENTS` で指定されたファイルを Read ツールで読む
-2. **main との差分ログを取得**:
+1. **前回リリースタグを特定**:
    ```bash
-   git log main..HEAD --oneline
+   git tag -l 'v*' --sort=-v:refname
    ```
-3. **main との差分（ファイル変更内容）を取得**:
+   先頭（最新）のタグを `v{前バージョン}` とする。
+2. **要件ドキュメントを読む**: 第1引数のファイルを Read ツールで読む
+3. **前回タグ以降の変更ログを取得**:
    ```bash
-   git diff main...HEAD
+   git log v{前バージョン}..main --oneline
    ```
-   差分が大きい場合は `git diff main...HEAD --stat` で概要を先に把握し、
-   必要なファイルだけ個別に Read で確認する
-4. **現在の CHANGELOG.md を読む**: `CHANGELOG.md` を Read ツールで読む
-5. **現在の README.md を読む**: `README.md` を Read ツールで読む
-6. **package.json のバージョンを確認**:
+4. **前回タグ以降の差分を取得**:
    ```bash
-   # Read ツールで package.json を読み "version" フィールドを取得
+   git diff v{前バージョン}...main --stat
    ```
+   概要を把握し、必要なファイルだけ個別に Read で確認する
+5. **現在の CHANGELOG.md / README.md / package.json を読む**（package.json は `"version"` フィールドの確認）
 
 ### Step 3: バージョンと日付の決定
 
-#### バージョンの決定（優先順位順）
+#### バージョンの決定
 
-1. **第2引数が指定されている場合** — その値を使用する（`v` prefix は除去して正規化。例: `v0.2.7` → `0.2.7`）
-2. **第2引数が省略されている場合** — `package.json` の `"version"` フィールドを Read ツールで読んで使用する
+1. **第2引数が指定されている場合** — その値を使用する（`v` prefix は除去して正規化）
+2. **第2引数が省略されている場合** — ユーザーに確認する（bump を含むため、自動決定はしない）
 
 #### 安全チェック（必須）
 
-決定したバージョンが CHANGELOG に既存エントリとして存在する場合は**処理を中断**し、以下の形式でユーザーに確認する：
+- 決定したバージョンが CHANGELOG に既存エントリとして存在する場合は**処理を中断**し、別バージョンの指定か上書きの了承をユーザーに確認する。
+- 決定したバージョンのタグ `v{バージョン}` が既に存在する場合も中断する。
+- **日付**: 今日の日付（YYYY-MM-DD 形式）
 
+### Step 4: リリース準備ブランチの作成
+
+```bash
+git switch -c docs/release-v{バージョン} main
 ```
-⚠️ CHANGELOG に [X.Y.Z] エントリが既に存在します。
-  - 別のバージョン番号を指定して再実行するか
-  - 既存エントリを上書きしても良い場合は「続行」と入力してください
-```
 
-ユーザーが「続行」または続行の意思を示した場合のみ、既存エントリを上書きして処理を進める。
-
-- **日付**: 今日の日付（YYYY-MM-DD 形式、MEMORY.md の currentDate を参照）
-
-### Step 4: CHANGELOG.md の更新
+### Step 5: CHANGELOG.md の更新
 
 `## [Unreleased]` セクションの直後に新バージョンのセクションを挿入する。
 
 #### 書き方のルール
 
-- **言語**: 英語（`docs/development/project-settings.md` の `commit-language: en` に準拠）
+- **言語**: 英語（`commit-language: en` に準拠）
 - **形式**: [Keep a Changelog](https://keepachangelog.com/) 準拠
 - **セクション**: `Added` / `Changed` / `Fixed` / `Removed` のうち該当するもの
-- **各項目**: `- **機能名**: 説明文` の形式。何を・どう変えたかを1文で明確に書く
+- **各項目**: `- **機能名**: 説明文` の形式。何を・どう変えたかを明確に書く
 - **情報源の優先順位**: 要件ドキュメント（ユーザー向け説明）> git diff（実装の事実）
 
 #### 盛り込む内容の判断基準
 
-- 要件ドキュメントに記載された機能（REQ-xxx）を中心に記述する
+- 要件ドキュメントに記載された機能を中心に記述する
 - git diff から読み取れる実装上の改善（UX 修正、バグ修正、リファクタリングの副産物）も含める
 - 内部実装の詳細（定数名、関数名、型名）はユーザー向けに言い換える
 - テスト・ドキュメント変更は CHANGELOG に記載しない
@@ -129,83 +133,70 @@ cd ~/work/ai/git-keizu
 [{新バージョン}]: https://github.com/numlia/git-keizu/compare/v{前バージョン}...v{新バージョン}
 ```
 
-前バージョンは既存の CHANGELOG エントリから読み取ること。
-
-### Step 5: README.md の更新
+### Step 6: README.md の更新
 
 `## Features` セクションのリストを更新する。
 
-#### 書き方のルール
-
 - **言語**: 英語
-- **形式**: `- **機能名**: 説明文` の箇条書き
-- **新機能**: 適切な位置に新しい bullet を追加する
-  - 関連する既存 bullet の近くに配置する（例: Branch Actions の隣に Remote Branch Actions）
-  - または既存 bullet の説明文に追記する（例: Commit Details に親ハッシュリンクの説明を追加）
+- **新機能**: 関連する既存 bullet の近くに新しい bullet を追加するか、既存 bullet の説明文に追記する
 - **既存機能**: 動作が変わった場合のみ説明文を更新する
-- **削除機能**: bullet を削除またはコメントアウトする
+- **変更しないもの**: `## Security` / `## Installation` / `## Contributing & Support` / `## License`、badge 行、タイトル行
 
-#### 変更しないもの
+### Step 7: package.json のバージョンバンプ
 
-- `## Security` セクション（機能変更でない限り手をつけない）
-- `## Installation` / `## Contributing & Support` / `## License` セクション
-- badge 行やタイトル行
+Edit ツールで `package.json` の `"version"` フィールドを `{バージョン}` へ更新する。
 
-### Step 6: コミット
-
-CHANGELOG.md と README.md をまとめて1コミットとして記録する。
-
-#### コミットメッセージの生成ルール
-
-- **形式**: `docs: {説明}` の prefix を使う
-- **言語**: Step 0 で確認した言語設定に従う
-  - 英語の場合: `docs: update CHANGELOG and README for v{version}`
-  - 日本語の場合: `docs: v{バージョン}の CHANGELOG と README を更新`
-- **🚫 ブランチ情報は絶対に手動で付けない**: Git Hook が自動付与するため `(#issue-number)` を含めない
-
-#### コミット手順
+### Step 8: コミット（2コミット構成）
 
 ```bash
-# Step 6-1: ステータス確認
-git status
-
-# Step 6-2: 対象ファイルをステージング（別々の Bash tool call で実行）
+# docs コミット
 git add CHANGELOG.md README.md
+git commit -m "docs: update CHANGELOG and README for v{バージョン}"
 
-# Step 6-3: コミット（HEREDOC 形式）
-git commit -m "$(cat <<'EOF'
-docs: {決定したメッセージ}
-EOF
-)"
+# bump コミット
+git add package.json
+git commit -m "chore: bump version to {バージョン}"
 ```
 
-### Step 7: 変更内容の確認と報告
+- コミットメッセージの言語は言語設定に従う（英語の場合は上記の定型）
+- 🚫 ブランチ情報 `(#issue-number)` は手動で付けない
 
-更新後、以下の形式でレポートを出力する:
+### Step 9: Push と Draft PR 作成
+
+```bash
+git push -u origin docs/release-v{バージョン}
+gh pr create --draft --assignee @me --base main --title "docs: prepare release v{バージョン}" --body "..."
+```
+
+PR 本文は `pr-language` 設定に従い、変更内容（CHANGELOG 追加・README 更新・バージョンバンプ）と「マージ後に `/release {バージョン}` でタグを作成する」旨を簡潔に記載する。
+
+### Step 10: 変更内容の確認と報告
 
 ```
 ## 📊 Report
 
-**Overview**: [バージョン X.Y.Z の CHANGELOG と README を更新・コミットした旨]
+**Overview**: [バージョン X.Y.Z のリリース準備 PR（docs + bump）を作成した旨]
 
-**Changed files**: 2 files
+**Changed files**: 3 files
 - `CHANGELOG.md`
 - `README.md`
+- `package.json`
+
+**PR**: #{番号}（Draft）
 
 **CHANGELOG の主な変更**:
 - Added: N 項目
-- Changed: N 項目
 
 **README の主な変更**:
 - [追加・変更した bullet の概要]
 
-**Next step**: /release X.Y.Z を実行してください
+**Next step**: PR #{番号} をマージ後、/release X.Y.Z を実行してください
 ```
 
 ## 注意事項
 
-- **コミットは自動実行**: Step 6 でドキュメント更新後に自動コミットする。手動の `/commit` は不要
+- **main へ直接コミットしない**: すべての変更はリリース準備ブランチ上で行う
 - **既存エントリを消さない**: CHANGELOG の過去バージョンエントリは一切変更しない
 - **`## [Unreleased]` は空のまま**: 新バージョンのセクションはその下に追加する
-- **要件外の変更も拾う**: 要件ドキュメントになくても git diff に含まれるユーザー向け改善は記述する
-- **重複チェック**: 追加しようとしているバージョンが CHANGELOG に既に存在する場合はユーザーに確認する
+- **要件外の変更も拾う**: 要件ドキュメントになくても前回タグ以降の差分に含まれるユーザー向け改善は記述する
+- **タグは作成しない**: タグ作成・push は `/release` の担当


### PR DESCRIPTION
# Issue

- N/A

# Background / Purpose

Stacked on #21. The `main` ruleset (pull_request required, no bypass) broke the old release flow, which committed the version bump directly on main and pushed it. This PR reshapes the two release skills to match the protected-main flow that #21 follows.

# Changes

- **`.claude/skills/update-release-docs/SKILL.md`** (prep): now collects changes since the previous release tag, updates CHANGELOG / README, bumps `package.json`, and delivers everything as a release-prep branch + draft PR. Tag creation is explicitly out of scope.
- **`.claude/skills/release/SKILL.md`** (execute): no longer creates the bump commit. It now verifies that the merged main already carries the release prep (version match, CHANGELOG entry), runs the CI gates, creates the `v*` tag, and asks the user to push **only the tag** (tag pushes are outside the branch ruleset, so the publish workflow still triggers).

# Impact / Compatibility

- Process documentation only; no extension code changes. First real exercise of the new flow will be `/release 0.9.0` after #21 merges.

# Merge order

1. Merge #21 (release prep v0.9.0)
2. This PR retargets onto main (stacked PR preview), then merge