### PR TITLE
docs: prepare release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-08-09
+
+This release changes nothing about how the extension behaves. It republishes the marketplace listing so that it picks up the rewritten README, and adds the changelog to the extension package.
+
+### Changed
+
+- **The README now leads with how to get started**: The README opens with a Getting Started section showing the two ways to open Git Keizu — the Source Control view and the Command Palette — with a screenshot of the Source Control entry point, and explains that the Status Bar item only appears once the extension has activated and detected a repository. The exhaustive feature list has been replaced with workflow-oriented Highlights, requirements now come before reference material, and the commands and settings tables are grouped under a single Reference section. Marketplace listings render the README bundled inside the extension package, so this release is what makes the rewrite visible on the Marketplace and Open VSX pages.
+- **The changelog is included in the extension package**: `CHANGELOG.md` was missing from the package, leaving the Changelog tab of the marketplace listing empty. It is now bundled, so release notes can be read directly from the marketplace page and from the installed extension.
+
 ## [0.9.0] - 2026-08-08
 
 This release makes detached HEAD worktrees visible: worktrees created without a branch — such as the throwaway worktrees AI coding tools create with `git worktree add <path> <commit>` — now appear in the graph, stay visible even when their commit is unreachable from any branch, and keep the graph up to date automatically as they come and go.
@@ -510,7 +519,8 @@ This release is a codebase-wide correctness and robustness pass: 32 defects foun
 
 Initial release as Git Keizu — forked from [neo-git-graph](https://github.com/asispts/neo-git-graph) (originally [Git Graph](https://github.com/mhutchie/vscode-git-graph) by mhutchie, MIT).
 
-[Unreleased]: https://github.com/numlia/git-keizu/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/numlia/git-keizu/compare/v0.9.1...HEAD
+[0.9.1]: https://github.com/numlia/git-keizu/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/numlia/git-keizu/compare/v0.8.4...v0.9.0
 [0.8.4]: https://github.com/numlia/git-keizu/compare/v0.8.3...v0.8.4
 [0.8.3]: https://github.com/numlia/git-keizu/compare/v0.8.2...v0.8.3

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "git-keizu",
   "displayName": "Git Keizu",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Git history graph / 日本語UI対応 — checkout, merge, rebase, cherry-pick, stash & worktree. Successor to Git Graph. Requires Git 2.32+.",
   "categories": [
     "SCM Providers",


### PR DESCRIPTION
# Issue

- N/A

# Background and purpose

Marketplace listings render the README bundled inside the VSIX rather than the one in the repository, and a published version cannot be replaced in place. The README rewrite in #24 therefore stays invisible to users until a new version is published. This PR prepares that release.

The extension itself is unchanged, so the bump is a patch.

# Changes

- Add the `[0.9.1]` section to CHANGELOG.md, covering the README rewrite and the CHANGELOG bundling from #24.
- Update the `[Unreleased]` and `[0.9.1]` link definitions.
- Bump `package.json` to 0.9.1.

# Impact and compatibility

- Breaking changes: ➖ None
- DB migrations: ➖ None
- Environment variables: ➖ None
- External APIs or schemas: ➖ None
- Authentication or authorization: ➖ None
- Performance: ➖ None
- Extension behavior: ➖ None. No code under `src/` or `web/` is touched.

# Verification

1. Confirm the `[0.9.1]` section sits directly below `## [Unreleased]` and that no earlier entry was modified.
2. Confirm the link definitions point at `v0.9.0...v0.9.1` and `v0.9.1...HEAD`.
3. Run `pnpm run package` and confirm the VSIX is built as 0.9.1 and contains both readme.md and changelog.md.

# Tests

- Automated tests: Not run because this PR changes documentation and the version field only. CI runs the full gate on this branch.
- Static verification: `pnpm run format` passed across 191 files.
- Packaging verification: `pnpm run package` produced git-keizu-0.9.1.vsix (26 files, 166.88 KB) containing readme.md and changelog.md.
- Tag verification: `v0.9.1` does not exist yet.

# Risks, concerns, and rollback

- Risk: Marketplace and Open VSX rendering of the rewritten README has not been previewed before publication.
- Risk: The Changelog tab can only be confirmed once 0.9.1 is published.
- Rollback: Revert commits f0561e6 and ebc925a. If the tag has already been pushed, publish a follow-up patch instead.

# Review points

- Confirm that the `[0.9.1]` entry describes the change from a user's point of view rather than as repository housekeeping.
- Confirm that a documentation-only republish is acceptable as a patch release.

# Pre-merge checklist

## Security

- ✅ No secrets or personal data added.
- ➖ No input validation, authorization, CSRF, or rate-limit behavior changed.

## Documentation

- ✅ CHANGELOG updated.
- ➖ README already updated in #24; no further change required.

# After merge

Run `/release 0.9.1` to verify main, create the `v0.9.1` tag, and trigger the publish workflow.
