### PR TITLE
chore: add CodeRabbit configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,13 @@
+# CodeRabbit review settings
+# Reference: https://docs.coderabbit.ai/reference/configuration
+#
+# Coding conventions are picked up automatically from CLAUDE.md / AGENTS.md,
+# so they are not duplicated here.
+
+language: ja-JP
+
+knowledge_base:
+  code_guidelines:
+    filePatterns:
+      - "docs/test-supplement.md"
+      - "docs/development/directory-structure.md"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,6 +6,11 @@
 
 language: ja-JP
 
+reviews:
+  auto_review:
+    # Draft PRs are skipped by default; this project wants them reviewed too.
+    drafts: true
+
 knowledge_base:
   code_guidelines:
     filePatterns:


### PR DESCRIPTION
## Background

CodeRabbit is installed on this repository but has no configuration file, so it runs entirely on defaults: review comments are written in English, and guideline documents outside `CLAUDE.md` are not used as review criteria. This adds a minimal configuration to address both.

## Changes

- Add `.coderabbit.yaml` at the repository root
- Set `language: ja-JP` so review comments and summaries are written in Japanese
- Register `docs/test-supplement.md` and `docs/development/directory-structure.md` through `knowledge_base.code_guidelines.filePatterns`, since they are only linked from `CLAUDE.md` and are not picked up on their own
- Keep coding conventions out of this file: `CLAUDE.md` and `AGENTS.md` are auto-detected as code guidelines, so restating them here would duplicate the source of truth
- Omit keys that only restate CodeRabbit defaults

## Verification

- Confirmed the file parses as valid YAML into the three expected keys
- Confirmed both files referenced by `filePatterns` exist in the repository


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * コードレビュー時の案内を日本語で提供するよう改善しました。
  * 開発ルールやディレクトリ構成に関するドキュメントを、レビュー時の参照情報として追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->