### PR TITLE
docs: prepare release v1.0.0

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,7 +4,7 @@
 # Coding conventions are picked up automatically from CLAUDE.md / AGENTS.md,
 # so they are not duplicated here.
 
-language: ja-JP
+language: en-US
 
 reviews:
   auto_review:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-08-30
+
+This release marks Git Keizu as a stable release. Git Keizu does not aim to reproduce everything Git can do — it deliberately carries only the operations that belong in a history graph, and leaves out the rest. That scope is now settled, and this release begins adding capabilities the upstream project does not have, starting with Branch Cleanup: a panel that gathers the facts needed to decide whether a local branch can be deleted.
+
+### Added
+
+- **Branch Cleanup panel**: A new toolbar button opens a temporary panel above the graph listing every local branch in the repository, each with the facts needed to judge whether it is still needed: whether it is an ancestor of a comparison branch, how many commits it is ahead and behind that branch, whether its tree differs from the comparison branch's, its upstream state (not set, present, or gone), whether a worktree is using it, and its last commit date. The comparison branch is chosen from a dropdown; left on Automatic, it resolves to the branch `origin/HEAD` points at, then a local `main`, then `master`, then the current branch, and the dropdown shows which branch the automatic choice landed on. No single safe-or-unsafe verdict is given: the facts are shown side by side and the decision stays with you. The panel is closed by default, runs no Git commands until it is opened, and refreshes together with the graph while open.
+- **Acting on a branch from the panel**: Each row offers **Show in Graph**, which filters the graph to that branch alone and scrolls to its tip, and **Delete...**, which opens the existing branch delete dialog — including its remote-deletion checkbox — with Force Delete off by default. Nothing is deleted automatically and no branch is deleted in bulk; every deletion still goes through that dialog one branch at a time. The delete action is not offered for the current branch, a branch a worktree is using, the branch selected for comparison, a row where any fact could not be determined, or while a refresh is in flight.
+- **Partial results instead of a blank panel**: When a comparison fails for one branch, only that row's ancestry and ahead/behind values are reported as unknown; when the worktree lookup fails, only the worktree column is. The panel reports a load failure as a whole only when the branch list itself cannot be read, and the graph behind it is left untouched. When no comparison branch can be resolved — a detached HEAD with no `main` or `master`, or a repository with no commits yet — the comparison columns say so rather than guessing.
+
+### Changed
+
+- **The "not fully merged" explanation now names the reference Git actually checks**: The explanation shown when a normal branch deletion is rejected previously said Git could not confirm the branch was merged into "its upstream branch or the current branch", which reads as though the current branch were an alternative even when an upstream is configured. It now states that Git checks the upstream branch, and the current branch only when no upstream is configured. The explanation also notes that a deletion opened from Branch Cleanup can be rejected even though the panel shows the branch as merged, because the panel's comparison branch and the reference Git checks are not necessarily the same. The guidance about confirming the branch before enabling Force Delete, the collapsible original Git output, and the conditions under which the explanation appears are unchanged.
+
 ## [0.10.1] - 2026-08-25
 
 This release fixes the overlay stacking order in the graph view: dialogs now always appear in front of the find widget instead of being partially hidden behind it.
@@ -539,7 +553,8 @@ This release is a codebase-wide correctness and robustness pass: 32 defects foun
 
 Initial release as Git Keizu — forked from [neo-git-graph](https://github.com/asispts/neo-git-graph) (originally [Git Graph](https://github.com/mhutchie/vscode-git-graph) by mhutchie, MIT).
 
-[Unreleased]: https://github.com/numlia/git-keizu/compare/v0.10.1...HEAD
+[Unreleased]: https://github.com/numlia/git-keizu/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/numlia/git-keizu/compare/v0.10.1...v1.0.0
 [0.10.1]: https://github.com/numlia/git-keizu/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/numlia/git-keizu/compare/v0.9.1...v0.10.0
 [0.9.1]: https://github.com/numlia/git-keizu/compare/v0.9.0...v0.9.1

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Right-click commits, branches, tags, stash entries, or uncommitted changes to ac
 - Checkout, cherry-pick, merge, rebase, create branches, manage tags, and apply or pop stashes.
 - Pull and push the current branch, including choosing an upstream when one has not been configured. Fetch automatically prunes stale remote-tracking references.
 - Common actions appear first, while less-used and destructive actions are grouped under **More…**. Confirmation dialogs expose relevant Git options before execution.
+- **Branch Cleanup** collects every local branch into one panel with the facts needed to decide whether it can be deleted — ancestry against a comparison branch, ahead/behind counts, tree differences, upstream state, worktree usage, and last commit date — then lets you show a branch in the graph or open its delete dialog. It gives no safe-or-unsafe verdict and deletes nothing on its own.
 - When a branch deletion is rejected because Git could not confirm the branch is fully merged, the error dialog explains why — including after squash merges and rebases — and what to check before using Force Delete, with the original Git output preserved in a collapsible section.
 
 ### Manage worktrees visually

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "git-keizu",
   "displayName": "Git Keizu",
-  "version": "0.10.1",
+  "version": "1.0.0",
   "description": "Git history graph / 日本語UI対応 — checkout, merge, rebase, cherry-pick, stash & worktree. Successor to Git Graph. Requires Git 2.32+.",
   "categories": [
     "SCM Providers",


### PR DESCRIPTION
Release preparation for v1.0.0. No behavior changes.

## Changes

- `CHANGELOG.md`: add the `1.0.0` section (Branch Cleanup panel, row actions, partial results; the reworded `not fully merged` explanation) and update the link definitions.
- `README.md`: add a Branch Cleanup bullet under "Run Git actions from the graph".
- `package.json`: bump `version` from `0.10.1` to `1.0.0`.

## Why 1.0.0

The scope of the project is settled: Git Keizu carries only the operations that belong in a history graph rather than reproducing all of Git, and this release starts adding capabilities the upstream project does not have. The settings namespace and command IDs are stable, with no deprecated entries.

## Next step

After merging, run `/release 1.0.0` to create and push the `v1.0.0` tag, which triggers publishing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Branch Cleanup パネルで、ローカルブランチの関係、差分、同期状態、ワークツリー使用状況、最終コミット日時を確認できるようになりました。
  * パネルからブランチをグラフに表示したり、削除ダイアログを開いたりできます。
  * 部分的な結果を表示できるようになりました。

* **改善**
  * 「完全にマージされていない」エラーの説明を分かりやすく更新しました。

* **ドキュメント**
  * Branch Cleanup の利用方法と v1.0.0 のリリース情報を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->